### PR TITLE
Add setOptions to set function

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const main = async () => {
   // }
 
   doc.title = 'fixed_title'
-  doc = await dao.set(doc)
+  doc = await dao.set(doc) // can also pass setOptions object (e.g. `doc = await dao.set(doc, { merge: true })`)
   console.log(doc)
   // {
   //   id: 'dQU413MsVLQRJ8elvr3y',

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@google-cloud/firestore'
 
 export declare interface IMapping { [key: string]: string }
+export declare interface ISetOptions { [key: string]: string }
 export declare interface IDocData {
   [extra: string]: any
 }
@@ -92,13 +93,13 @@ export class FirestoreSimple {
     }
   }
 
-  public async set (object: IDocObject) {
+  public async set (object: IDocObject, setOptions?: ISetOptions) {
     if (!object.id) throw new Error('Argument object must have "id" property')
 
     const docId = object.id
     const setDoc = this._toDoc(object)
 
-    await this.collectionRef.doc(docId).set(setDoc)
+    await this.collectionRef.doc(docId).set(setDoc, setOptions)
     return object
   }
 


### PR DESCRIPTION
This PR updates the `set` function to allow for an optional [`setOptions`](https://firebase.google.com/docs/reference/js/firebase.firestore.DocumentReference#set) object to be passed.

fyi, when installing my forked library through `npm install github:ahaider48/Firestore-simple --save` I wasn't getting the `dist` folder in my node modules. I had to change `prepublish` to [`prepare`](https://docs.npmjs.com/misc/scripts#deprecation-note) in my fork's `package.json` for it to work. (using npm v6.4.1)