### PR TITLE
Add add() in runTransaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ await firestore.runTransaction(async (transaction) => {
 
   // Update document
   transaction.set(docRef, { name: docId })
+
+  // Add new document
+  const newDocRef = collection.doc()
+  transaction.set(newDocRef, { name: newDocRef.id })
 })
 
 // firestore-simple transaction
@@ -275,6 +279,8 @@ await firestoreSimple.runTransaction(async (_tx) => {
   await dao.fetch(docId)
 
   await dao.set({ id: docId, name: docId })
+
+  await dao.add({ name: 'new doc' })
 })
 ```
 

--- a/__tests__/basic.test.ts
+++ b/__tests__/basic.test.ts
@@ -131,4 +131,20 @@ describe('Basic', () => {
 
     expect(snapshot.exists).toBeFalsy()
   })
+
+  describe('docRef', () => {
+    it('with no argument should return new document ref', async () => {
+      const docRef = dao.docRef()
+
+      const fetchedDoc = await dao.fetch(docRef.id)
+      expect(fetchedDoc).toBeUndefined()
+    })
+
+    it('with id argument should return exists document ref', async () => {
+      const docRef = dao.docRef(existsDocId)
+
+      const fetchedDoc = await dao.fetch(docRef.id)
+      expect(fetchedDoc).not.toBeUndefined()
+    })
+  })
 })

--- a/__tests__/transaction.test.ts
+++ b/__tests__/transaction.test.ts
@@ -54,12 +54,12 @@ describe('transaction', () => {
       await txFirestoreSimple.runTransaction(async () => {
         await txDao.set(updatedDoc)
 
-        // updated can't see outside transaction
+        // Set document can't see outside transaction
         const outTxFetched = await dao.fetch(doc.id)
         expect(outTxFetched).toEqual(doc)
       })
 
-      // updated can see after transaction
+      // Set document can see after transaction
       const fetched = await dao.fetch(doc.id)
       expect(fetched).toEqual(updatedDoc)
     })
@@ -71,12 +71,12 @@ describe('transaction', () => {
       await txFirestoreSimple.runTransaction(async () => {
         await txDao.delete(doc.id)
 
-        // updated can't see outside transaction
+        // Deleted document can't see outside transaction
         const outTxFetched = await dao.fetch(doc.id)
         expect(outTxFetched).toEqual(doc)
       })
 
-      // updated can see after transaction
+      // Deleted document can see after transaction
       const fetched = await dao.fetch(doc.id)
       expect(fetched).toBeUndefined()
     })
@@ -184,14 +184,14 @@ describe('transaction', () => {
         await txDao.set(updatedDoc)
         await txAnotherDao.set(updatedAnotherDoc)
 
-        // updated can't see outside transaction
+        // Updated document can't see outside transaction
         const outTxFetched = await dao.fetch(doc.id)
         expect(outTxFetched).toEqual(doc)
         const outTxAnotherFetched = await anotherDao.fetch(anotherDoc.id)
         expect(outTxAnotherFetched).toEqual(anotherDoc)
       })
 
-      // updated can see after transaction
+      // Updated document can see after transaction
       const fetched = await dao.fetch(doc.id)
       expect(fetched).toEqual(updatedDoc)
       const anotherFetched = await anotherDao.fetch(anotherDoc.id)

--- a/__tests__/transaction.test.ts
+++ b/__tests__/transaction.test.ts
@@ -81,6 +81,24 @@ describe('transaction', () => {
       expect(fetched).toBeUndefined()
     })
 
+    it('add', async () => {
+      let newId: string | undefined
+      const doc = { title: 'aaa' }
+
+      await txFirestoreSimple.runTransaction(async () => {
+        newId = await txDao.add(doc)
+
+        // Added document can't see outside transaction
+        const outTxFetched = await dao.fetch(newId)
+        expect(outTxFetched).toBeUndefined()
+      })
+
+      if (!newId) return
+      // Added document can see after transaction
+      const fetched = await dao.fetch(newId)
+      expect(fetched).not.toBeUndefined()
+    })
+
     it('fetch after set in transaction should be error', async () => {
       const doc = { id: 'test1', title: 'aaa' }
       const updatedDoc = { id: 'test1', title: 'bbb' }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import {
   CollectionReference,
+  DocumentReference,
   DocumentSnapshot,
   Firestore,
   Query,
   QuerySnapshot,
-  DocumentReference,
 } from '@google-cloud/firestore'
 import { Assign } from 'utility-types'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   Firestore,
   Query,
   QuerySnapshot,
+  DocumentReference,
 } from '@google-cloud/firestore'
 import { Assign } from 'utility-types'
 
@@ -120,8 +121,9 @@ export class FirestoreSimpleCollection<T extends HasId> {
     return this._decode(obj)
   }
 
-  public docRef (id: string) {
-    return this.collectionRef.doc(id)
+  public docRef (id?: string) {
+    if (id) return this.collectionRef.doc(id)
+    return this.collectionRef.doc()
   }
 
   public async fetch (id: string): Promise <T | undefined> {
@@ -159,8 +161,15 @@ export class FirestoreSimpleCollection<T extends HasId> {
   }
 
   public async add (obj: Assign<T, NullableId>) {
+    let docRef: DocumentReference
     const doc = this._toDoc(obj)
-    const docRef = await this.collectionRef.add(doc)
+
+    if (this.context.tx) {
+      docRef = this.docRef()
+      await this.context.tx.set(docRef, doc)
+    } else {
+      docRef = await this.collectionRef.add(doc)
+    }
     return docRef.id
   }
 


### PR DESCRIPTION
Original firestore does not provide add() in transaction.
But add() is just shorthand for ```collection('foo').doc().set({ })```

So it is easy to implement add() in runTransaction.