### PR TITLE
Improve generic typing

### DIFF
--- a/__tests__/decode.test.ts
+++ b/__tests__/decode.test.ts
@@ -10,44 +10,68 @@ interface BookDoc {
   book_title: string
 }
 
+class BookClass {
+  constructor (public id: string, public bookTitle: string) { }
+}
+
 const firestore = initFirestore()
 const collectionPath = createRandomCollectionName()
 const firestoreSimple = new FirestoreSimple(firestore)
 
 describe('decode', () => {
-  const dao = firestoreSimple.collection<Book, BookDoc>({path: collectionPath,
-    decode: (doc) => {
-      return {
-        id: doc.id,
-        bookTitle: doc.book_title,
-      }
-    },
-  })
-
   // Delete all documents. (= delete collection)
   afterEach(async () => {
     await deleteCollection(firestore, collectionPath)
   })
-  
-  it('fetch with decode', async () => {
-    const title = 'add1'
-    const docRef = await dao.collectionRef.add({
-      book_title: title,
+
+  describe('to object with different key', () => {
+    const dao = firestoreSimple.collection<Book, BookDoc>({path: collectionPath,
+      decode: (doc) => {
+        return {
+          id: doc.id,
+          bookTitle: doc.book_title,
+        }
+      },
     })
 
-    const fetchedDoc = await dao.fetch(docRef.id)
-    expect(fetchedDoc).toEqual({ id: docRef.id, bookTitle: title })
+    it('fetch with decode', async () => {
+      const title = 'add1'
+      const docRef = await dao.collectionRef.add({
+        book_title: title,
+      })
+
+      const fetchedDoc = await dao.fetch(docRef.id)
+      expect(fetchedDoc).toEqual({ id: docRef.id, bookTitle: title })
+    })
+
+    it('where with decode', async () => {
+      const title = 'add2'
+      const docRef = await dao.collectionRef.add({
+        book_title: title,
+      })
+
+      const fetchedDoc = await dao.where('book_title', '==', title).fetch()
+      expect(fetchedDoc).toEqual([
+        { id: docRef.id, bookTitle: title }
+      ])
+    })
   })
 
-  it('where with decode', async () => {
-    const title = 'add2'
-    const docRef = await dao.collectionRef.add({
-      book_title: title,
+  describe('to class instance with same key', () => {
+    const dao = firestoreSimple.collection<BookClass>({path: collectionPath,
+      decode: (doc) => {
+        return new BookClass(doc.id, doc.bookTitle)
+      },
     })
 
-    const fetchedDoc = await dao.where('book_title', '==', title).fetch()
-    expect(fetchedDoc).toEqual([
-      { id: docRef.id, bookTitle: title }
-    ])
+    it('fetch with decode', async () => {
+      const title = 'add1'
+      const docRef = await dao.collectionRef.add({
+        bookTitle: title,
+      })
+
+      const fetchedDoc = await dao.fetch(docRef.id)
+      expect(fetchedDoc).toStrictEqual(new BookClass(docRef.id, title))
+    })
   })
 })

--- a/__tests__/decode.test.ts
+++ b/__tests__/decode.test.ts
@@ -6,12 +6,16 @@ interface Book {
   bookTitle: string
 }
 
+interface BookDoc {
+  book_title: string
+}
+
 const firestore = initFirestore()
 const collectionPath = createRandomCollectionName()
 const firestoreSimple = new FirestoreSimple(firestore)
 
 describe('decode', () => {
-  const dao = firestoreSimple.collection<Book>({path: collectionPath,
+  const dao = firestoreSimple.collection<Book, BookDoc>({path: collectionPath,
     decode: (doc) => {
       return {
         id: doc.id,

--- a/__tests__/encode.test.ts
+++ b/__tests__/encode.test.ts
@@ -10,47 +10,75 @@ interface BookDoc {
   book_title: string
 }
 
+class BookClass {
+  constructor (public id: string, public bookTitle: string) { }
+}
+
 const firestore = initFirestore()
 const collectionPath = createRandomCollectionName()
 const firestoreSimple = new FirestoreSimple(firestore)
 
 describe('encode', () => {
-  const dao = firestoreSimple.collection<Book, BookDoc>({path: collectionPath,
-    encode: (book) => {
-      return {
-        book_title: book.bookTitle,
-      }
-    },
-  })
-
   // Delete all documents. (= delete collection)
   afterEach(async () => {
     await deleteCollection(firestore, collectionPath)
   })
 
-  it('add with encode', async () => {
-    const title = 'add'
-    const doc = {
-      bookTitle: title,
-    }
-    const addedId = await dao.add(doc)
+  describe('from object with different key', () => {
+    const dao = firestoreSimple.collection<Book, BookDoc>({path: collectionPath,
+      encode: (book) => {
+        return {
+          book_title: book.bookTitle,
+        }
+      },
+    })
 
-    const fetchedDoc = await dao.collectionRef.doc(addedId).get()
-    expect(fetchedDoc.data()).toEqual({ book_title: title })
+    it('add with encode', async () => {
+      const title = 'add'
+      const doc = {
+        bookTitle: title,
+      }
+      const addedId = await dao.add(doc)
+
+      const fetchedDoc = await dao.collectionRef.doc(addedId).get()
+      expect(fetchedDoc.data()).toEqual({ book_title: title })
+    })
+
+    it('set with encode', async () => {
+      const exsitDoc = await dao.collectionRef.add({
+        book_title: 'hogehoge',
+      })
+      const title = 'set'
+      const setDoc = {
+        id: exsitDoc.id,
+        bookTitle: title,
+      }
+      await dao.set(setDoc)
+
+      const fetchedDoc = await dao.collectionRef.doc(exsitDoc.id).get()
+      expect(fetchedDoc.data()).toEqual({ book_title: title })
+    })
   })
 
-  it('set with encode', async () => {
-    const exsitDoc = await dao.collectionRef.add({
-      book_title: 'hogehoge',
+  describe('from class instance with same key', () => {
+    const dao = firestoreSimple.collection<Book>({path: collectionPath,
+      encode: (book) => {
+        return {
+          bookTitle: book.bookTitle,
+        }
+      },
     })
-    const title = 'set'
-    const setDoc = {
-      id: exsitDoc.id,
-      bookTitle: title,
-    }
-    await dao.set(setDoc)
 
-    const fetchedDoc = await dao.collectionRef.doc(exsitDoc.id).get()
-    expect(fetchedDoc.data()).toEqual({ book_title: title })
+    it('set with encode', async () => {
+      const exsitDoc = await dao.collectionRef.add({
+        bookTitle: 'hogehoge',
+      })
+      const title = 'set'
+      const setDoc = new BookClass(exsitDoc.id, title)
+      await dao.set(setDoc)
+
+      const fetchedDoc = await dao.collectionRef.doc(exsitDoc.id).get()
+      expect(fetchedDoc.data()).toEqual({ bookTitle: title })
+    })
   })
 })

--- a/__tests__/encode.test.ts
+++ b/__tests__/encode.test.ts
@@ -6,12 +6,16 @@ interface Book {
   bookTitle: string
 }
 
+interface BookDoc {
+  book_title: string
+}
+
 const firestore = initFirestore()
 const collectionPath = createRandomCollectionName()
 const firestoreSimple = new FirestoreSimple(firestore)
 
 describe('encode', () => {
-  const dao = firestoreSimple.collection<Book>({path: collectionPath,
+  const dao = firestoreSimple.collection<Book, BookDoc>({path: collectionPath,
     encode: (book) => {
       return {
         book_title: book.bookTitle,

--- a/__tests__/encode_decode.test.ts
+++ b/__tests__/encode_decode.test.ts
@@ -7,12 +7,17 @@ interface Book {
   created: Date
 }
 
+interface BookDoc {
+  book_title: string,
+  created: Date,
+}
+
 const firestore = initFirestore()
 const collectionPath = createRandomCollectionName()
 const firestoreSimple = new FirestoreSimple(firestore)
 
 describe('encode and decode', () => {
-  const dao = firestoreSimple.collection<Book>({path: collectionPath,
+  const dao = firestoreSimple.collection<Book, BookDoc>({path: collectionPath,
     encode: (book) => {
       return {
         book_title: book.bookTitle,

--- a/__tests__/factory_subcollection.test.ts
+++ b/__tests__/factory_subcollection.test.ts
@@ -1,10 +1,15 @@
 import { FirestoreSimple, FirestoreSimpleCollection, Encodable, Decodable } from '../src'
 import { createRandomCollectionName, deleteCollection, initFirestore } from './util'
 
-interface TestDoc {
+interface Book {
   id: string,
   title: string,
   createdAt: Date
+}
+
+interface BookDoc {
+  title: string,
+  created_at: Date,
 }
 
 const firestore = initFirestore()
@@ -17,13 +22,13 @@ describe('Factory and Subcollection', () => {
     await deleteCollection(firestore, collectionPath)
   })
 
-  const encodeFunc: Encodable<TestDoc> = (obj) => {
+  const encodeFunc: Encodable<Book, BookDoc> = (obj) => {
     return {
       title: obj.title,
       created_at: obj.createdAt,
     }
   }
-  const decodeFunc: Decodable<TestDoc> = (doc) => {
+  const decodeFunc: Decodable<Book, BookDoc> = (doc) => {
     return {
       id: doc.id,
       title: doc.title,
@@ -33,7 +38,7 @@ describe('Factory and Subcollection', () => {
 
   describe('FirestoreSimple.collectionFactory', () => {
     it('should has same encode function', async () => {
-      const factory = firestoreSimple.collectionFactory<TestDoc>({
+      const factory = firestoreSimple.collectionFactory<Book, BookDoc>({
         encode: encodeFunc,
       })
 
@@ -41,7 +46,7 @@ describe('Factory and Subcollection', () => {
     })
 
     it('should has same decode function', async () => {
-      const factory = firestoreSimple.collectionFactory<TestDoc>({
+      const factory = firestoreSimple.collectionFactory<Book, BookDoc>({
         decode: decodeFunc,
       })
 
@@ -51,11 +56,11 @@ describe('Factory and Subcollection', () => {
 
   describe('FirestoreSimpleCollectionFactory.create', () => {
     const subcollectionPath = `${collectionPath}/test1/sub`
-    const factory = firestoreSimple.collectionFactory<TestDoc>({
+    const factory = firestoreSimple.collectionFactory<Book, BookDoc>({
       encode: encodeFunc,
       decode: decodeFunc,
     })
-    let dao: FirestoreSimpleCollection<TestDoc>
+    let dao: FirestoreSimpleCollection<Book, BookDoc>
 
     beforeEach(async () => {
       dao = factory.create(subcollectionPath)

--- a/__tests__/on_snapshot.test.ts
+++ b/__tests__/on_snapshot.test.ts
@@ -7,12 +7,17 @@ interface Book {
   created: Date
 }
 
+interface BookDoc {
+  book_title: string,
+  created: Date
+}
+
 const firestore = initFirestore()
 const collectionPath = createRandomCollectionName()
 const firestoreSimple = new FirestoreSimple(firestore)
 
 describe('on_snapshot test', () => {
-  const dao = firestoreSimple.collection<Book>({path: collectionPath,
+  const dao = firestoreSimple.collection<Book, BookDoc>({path: collectionPath,
     encode: (book) => {
       return {
         book_title: book.bookTitle,

--- a/__tests__/query_on_snapshot.test.ts
+++ b/__tests__/query_on_snapshot.test.ts
@@ -8,12 +8,18 @@ interface Book {
   bookId: number,
 }
 
+interface BookDoc {
+  book_title: string,
+  created: Date,
+  book_id: number
+}
+
 const firestore = initFirestore()
 const collectionPath = createRandomCollectionName()
 const firestoreSimple = new FirestoreSimple(firestore)
 
 describe('query on_snapshot test', () => {
-  const dao = firestoreSimple.collection<Book>({path: collectionPath,
+  const dao = firestoreSimple.collection<Book, BookDoc>({path: collectionPath,
     encode: (book) => {
       return {
         book_title: book.bookTitle,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
   Query,
   QuerySnapshot,
 } from '@google-cloud/firestore'
-import { Optional } from 'utility-types'
+import { Omit, Optional } from 'utility-types'
 
 type HasId = { id: string }
 type HasIdObject = { id: string, [key: string]: any }
@@ -17,6 +17,7 @@ type Storable<T> = { [P in keyof T]: P extends 'id' ? T[P] : T[P] | FieldValue }
 type HasSameKeyObject<T> = { [P in keyof T]: any }
 type OptionalIdStorable<T extends HasId> = Optional<Storable<T>, 'id'>
 type QueryKey<T> = { [K in keyof T]: K }[keyof T] | FirebaseFirestore.FieldPath
+type OmitId<T> = Omit<T, 'id'>
 export type Encodable<T extends HasId, S = FirebaseFirestore.DocumentData> = (obj: OptionalIdStorable<T>) => Storable<S>
 export type Decodable<T extends HasId, S = HasIdObject> = (doc: HasSameKeyObject<S> & HasId) => T
 
@@ -30,7 +31,7 @@ export class FirestoreSimple {
   constructor (firestore: Firestore) {
     this.context = { firestore, tx: undefined }
   }
-  public collection<T extends HasId, S = T> ({ path, encode, decode }: {
+  public collection<T extends HasId, S = OmitId<T>> ({ path, encode, decode }: {
     path: string,
     encode?: Encodable<T, S>,
     decode?: Decodable<T, S>,
@@ -43,7 +44,7 @@ export class FirestoreSimple {
     return factory.create(path)
   }
 
-  public collectionFactory<T extends HasId, S = T> ({ encode, decode }: {
+  public collectionFactory<T extends HasId, S = OmitId<T>> ({ encode, decode }: {
     encode?: Encodable<T, S>,
     decode?: Decodable<T, S>,
   }) {
@@ -63,7 +64,7 @@ export class FirestoreSimple {
   }
 }
 
-class CollectionFactory<T extends HasId, S = T> {
+class CollectionFactory<T extends HasId, S = OmitId<T>> {
   public context: Context
   public encode?: Encodable<T, S>
   public decode?: Decodable<T, S>
@@ -88,7 +89,7 @@ class CollectionFactory<T extends HasId, S = T> {
   }
 }
 
-export class FirestoreSimpleCollection<T extends HasId, S = T> {
+export class FirestoreSimpleCollection<T extends HasId, S = OmitId<T>> {
   public context: Context
   public collectionRef: CollectionReference
   public encode?: Encodable<T, S>


### PR DESCRIPTION
Add 2nd generic argument for more strict typing.
It declare Firestore document schema and used for showing usable key name in `encode`, `where`, `orderBy`.

You can skip 2nd argument If your interface or class use for 1st type argument and Firestore document schema has same keys.
If skip 2nd argument, it derived from 1st type argument.  

# TODO
- [x] Implement
- [x] Fix tests
- [x] dog fooding