### PR TITLE
Pin actions/checkout version to v1

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -12,7 +12,7 @@ jobs:
       image: ${{ matrix.container }}
     steps:
     # Prepare
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: Create firebase secret json
       run: echo "${{ secrets.FIREBASE_SECRET }}" | base64 --decode > firebase_secret.json
     - name: "Show version"


### PR DESCRIPTION
ref https://github.com/Kesin11/Firestore-simple/pull/74/checks?check_run_id=337736723

actions/checkout@master fail to checkout by git version issue.
Maybe their master branch is not stable.