### PR TITLE
Support collectionGroup

### DIFF
--- a/__tests__/collection_group.test.ts
+++ b/__tests__/collection_group.test.ts
@@ -1,0 +1,47 @@
+import { FirestoreSimple } from '../src'
+import { createRandomCollectionName, deleteCollection, initFirestore } from './util'
+
+interface TestDoc {
+  id: string,
+  title: string,
+  order: number,
+}
+
+const expectTitles = ['aaa', 'bbb', 'ccc', 'ddd']
+const collectionId = 'collection_group'
+
+const firestore = initFirestore()
+const collectionPath = createRandomCollectionName()
+const firestoreSimple = new FirestoreSimple(firestore)
+
+describe('collectionGroup', () => {
+  beforeEach(async () => {
+    await firestore.collection(`${collectionPath}/1/${collectionId}`).add({ title: expectTitles[0], order: 2 })
+    await firestore.collection(`${collectionPath}/1/${collectionId}`).add({ title: expectTitles[1], order: 1 })
+    await firestore.collection(`${collectionPath}/2/${collectionId}`).add({ title: expectTitles[2], order: 3 })
+    await firestore.collection(`${collectionPath}/3/${collectionId}`).add({ title: expectTitles[3], order: 4 })
+  })
+
+  afterEach(async () => {
+    await deleteCollection(firestore, `${collectionPath}/1/${collectionId}`)
+    await deleteCollection(firestore, `${collectionPath}/2/${collectionId}`)
+    await deleteCollection(firestore, `${collectionPath}/3/${collectionId}`)
+  })
+
+  it('fetch', async () => {
+    const query = firestoreSimple.collectionGroup<TestDoc>({ collectionId })
+    const docs = await query.fetch()
+
+    const actualTitles = docs.map((doc) => doc.title)
+    expect(actualTitles).toEqual(expectTitles)
+  })
+
+  it('where', async () => {
+    const expectTitle = 'aaa'
+    const query = firestoreSimple.collectionGroup<TestDoc>({ collectionId })
+    const docs = await query.where('title', '==', 'aaa').fetch()
+
+    const actualTitles = docs.map((doc) => doc.title)
+    expect(actualTitles).toEqual([expectTitle])
+  })
+})

--- a/__tests__/factory_subcollection.test.ts
+++ b/__tests__/factory_subcollection.test.ts
@@ -78,14 +78,6 @@ describe('Factory and Subcollection', () => {
       expect(dao.context).toBe(firestoreSimple.context)
     })
 
-    it('should has same encode function', async () => {
-      expect(dao.encode).toBe(encodeFunc)
-    })
-
-    it('should has same decode function', async () => {
-      expect(dao.decode).toBe(decodeFunc)
-    })
-
     it('set with encode/decode by created dao', async () => {
       const now = new Date()
       const doc = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,18 +250,18 @@ export class FirestoreSimpleCollection<T extends HasId, S = OmitId<T>> {
   }
 
   where (fieldPath: QueryKey<S>, opStr: FirebaseFirestore.WhereFilterOp, value: any): FirestoreSimpleQuery<T, S> {
-    const query = new FirestoreSimpleQuery<T, S>(this)
-    return query.where(fieldPath, opStr, value)
+    const query = this.collectionRef.where(fieldPath as string | FirebaseFirestore.FieldPath, opStr, value)
+    return new FirestoreSimpleQuery<T, S>(this, query)
   }
 
   orderBy (fieldPath: QueryKey<S>, directionStr?: FirebaseFirestore.OrderByDirection): FirestoreSimpleQuery<T, S> {
-    const query = new FirestoreSimpleQuery<T, S>(this)
-    return query.orderBy(fieldPath, directionStr)
+    const query = this.collectionRef.orderBy(fieldPath as string | FirebaseFirestore.FieldPath, directionStr)
+    return new FirestoreSimpleQuery<T, S>(this, query)
   }
 
   limit (limit: number): FirestoreSimpleQuery<T, S> {
-    const query = new FirestoreSimpleQuery<T, S>(this)
-    return query.limit(limit)
+    const query = this.collectionRef.limit(limit)
+    return new FirestoreSimpleQuery<T, S>(this, query)
   }
 
   onSnapshot (callback: (
@@ -276,35 +276,20 @@ export class FirestoreSimpleCollection<T extends HasId, S = OmitId<T>> {
 }
 
 class FirestoreSimpleQuery<T extends HasId, S> {
-  query?: Query = undefined
-  constructor (public collection: FirestoreSimpleCollection<T, S>) { }
+  constructor (public collection: FirestoreSimpleCollection<T, S>, public query: Query) { }
 
   where (fieldPath: QueryKey<S>, opStr: FirebaseFirestore.WhereFilterOp, value: any): this {
-    const _fieldPath = fieldPath as string | FirebaseFirestore.FieldPath
-    if (!this.query) {
-      this.query = this.collection.collectionRef.where(_fieldPath, opStr, value)
-    } else {
-      this.query = this.query.where(_fieldPath, opStr, value)
-    }
+    this.query = this.query.where(fieldPath as string | FirebaseFirestore.FieldPath, opStr, value)
     return this
   }
 
   orderBy (fieldPath: QueryKey<S>, directionStr?: FirebaseFirestore.OrderByDirection): this {
-    const _fieldPath = fieldPath as string | FirebaseFirestore.FieldPath
-    if (!this.query) {
-      this.query = this.collection.collectionRef.orderBy(_fieldPath, directionStr)
-    } else {
-      this.query = this.query.orderBy(_fieldPath, directionStr)
-    }
+    this.query = this.query.orderBy(fieldPath as string | FirebaseFirestore.FieldPath, directionStr)
     return this
   }
 
   limit (limit: number): this {
-    if (!this.query) {
-      this.query = this.collection.collectionRef.limit(limit)
-    } else {
-      this.query = this.query.limit(limit)
-    }
+    this.query = this.query.limit(limit)
     return this
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,15 @@ export class FirestoreSimple {
     })
   }
 
+  collectionGroup<T extends HasId, S = OmitId<T>> ({ collectionId, decode }: {
+    collectionId: string,
+    decode?: Decodable<T, S>,
+  }): FirestoreSimpleQuery<T, S> {
+    const query = this.context.firestore.collectionGroup(collectionId)
+    const converter = new FirestoreSimpleConverter({ decode })
+    return new FirestoreSimpleQuery<T, S>(converter, this.context, query)
+  }
+
   async runTransaction (updateFunction: (tx: FirebaseFirestore.Transaction) => Promise<any>): Promise<void> {
     await this.context.firestore.runTransaction(async (tx) => {
       this.context.tx = tx


### PR DESCRIPTION
Support Firestore collectionGroup feature.
https://googleapis.dev/nodejs/firestore/latest/Firestore.html#collectionGroup

Split encode/decode feature from FirestoreSimpleCollection to FirestoreSImpleConverter class.

BREAKING CHANGE:

- Remove FirestoreSimpleCollection.fetchByQuery()