### PR TITLE
feat: Add bulkAdd()

### DIFF
--- a/__tests__/batch.test.ts
+++ b/__tests__/batch.test.ts
@@ -18,6 +18,20 @@ describe('batch', () => {
     await deleteCollection(firestore, collectionPath)
   })
 
+  it('bulkAdd', async () => {
+    const docs = [
+      { title: 'aaa' },
+      { title: 'bbb' },
+      { title: 'ccc' },
+    ]
+    await dao.bulkAdd(docs)
+    const fetchedDocs = await dao.fetchAll()
+
+    const actualTitles = fetchedDocs.map((doc) => doc.title).sort()
+    const expectTitles = docs.map((doc) => doc.title).sort()
+    expect(actualTitles).toEqual(expectTitles)
+  })
+
   it('bulkSet', async () => {
     const docs = [
       { id: 'test1', title: 'aaa' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,6 +286,20 @@ export class FirestoreSimpleCollection<T extends HasId, S = OmitId<T>> {
     return id
   }
 
+  async bulkAdd (objects: Array<OptionalIdStorable<T>>): Promise<FirebaseFirestore.WriteResult[]> {
+    const batch = this.context.firestore.batch()
+    this.context.batch = batch
+
+    objects.forEach((obj) => {
+      const docRef = this.docRef()
+      const doc = this.converter.encode(obj)
+      batch.set(docRef, doc)
+    })
+    const writeBatch = await batch.commit()
+    this.context.batch = undefined
+    return writeBatch
+  }
+
   async bulkSet (objects: Array<Storable<T>>): Promise<FirebaseFirestore.WriteResult[]> {
     const batch = this.context.firestore.batch()
     this.context.batch = batch


### PR DESCRIPTION
Add `bulkAdd()` method it likes `bulkSet()` but creating document with random id.

Original Firestore does not provide `add()` with batch. So `bulkAdd()` is only firestore-simple feature.