### PR TITLE
Bugfix 'update' accept generic type S

### DIFF
--- a/__tests__/encode_decode.test.ts
+++ b/__tests__/encode_decode.test.ts
@@ -73,4 +73,18 @@ describe('encode and decode', () => {
     const fetchedBook = await dao.fetch(setBook.id)
     expect(fetchedBook).toEqual(setBook)
   })
+
+  it('update with encode/decode accept "encoded" key name', async () => {
+    const doc = {
+      book_title: 'exists_book',
+      created: now,
+    }
+    const docRef = await dao.collectionRef.add(doc)
+
+    const updatedTitle = 'update'
+    await dao.update({ id: docRef.id, book_title: updatedTitle })
+
+    const fetchedBook = await dao.fetch(docRef.id)
+    expect(fetchedBook!.bookTitle).toEqual(updatedTitle)
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,7 +251,7 @@ export class FirestoreSimpleCollection<T extends HasId, S = OmitId<T>> {
     return this.add(obj)
   }
 
-  async update (obj: PartialStorable<T>): Promise<string> {
+  async update (obj: PartialStorable<S & HasId>): Promise<string> {
     if (!obj.id) throw new Error('Argument object must have "id" property')
 
     const docRef = this.docRef(obj.id)


### PR DESCRIPTION
**BREAKING CHANGES**

Change `update` argument type `PartialStorable<T>` to `PartialStorable<S & HasId>`.
If you create FirestoreSimple.collection instance with `encode` and that function return object that has alternate key name from T, `update` request invalid key name.

For example,

```js
interface Book {
  id: string,
  bookTitle: string,
  created: Date,
}

interface BookDoc {
  book_title: string,
  created: Date,
}

const dao = firestoreSimple.collection<Book, BookDoc>({
  path: collectionPath,
  encode: (book) => {
    return {
      book_title: book.bookTitle,
      created: book.created,
    }
  }
}

// Type is OK. But 'update' can not work.
await dao.update({ id: 'foo', BookTitle: 'fix title' })

// Type is NG. But 'update' can work.
await dao.update({ id: 'foo', book_title: 'fix title' })
```

later one is correct. So this patch fix `update` argument type correctly.