### PR TITLE
WIP: Try supporting Firestore Web SDK

### DIFF
--- a/__tests__/admin/factory_subcollection.test.ts
+++ b/__tests__/admin/factory_subcollection.test.ts
@@ -1,6 +1,4 @@
-import { FirestoreSimpleAdmin } from '../../src'
-import { Encodable, Decodable } from '../../src/admin/types'
-import { AdminCollection } from '../../src/admin/collection'
+import { FirestoreSimpleAdmin, AdminEncodable, AdminDecodable, AdminCollection } from '../../src'
 import { createRandomCollectionName, deleteCollection, initFirestore } from './util'
 
 interface Book {
@@ -24,13 +22,13 @@ describe('Factory and Subcollection', () => {
     await deleteCollection(firestore, collectionPath)
   })
 
-  const encodeFunc: Encodable<Book, BookDoc> = (obj) => {
+  const encodeFunc: AdminEncodable<Book, BookDoc> = (obj) => {
     return {
       title: obj.title,
       created_at: obj.createdAt,
     }
   }
-  const decodeFunc: Decodable<Book, BookDoc> = (doc) => {
+  const decodeFunc: AdminDecodable<Book, BookDoc> = (doc) => {
     return {
       id: doc.id,
       title: doc.title,

--- a/__tests__/web/basic.test.ts
+++ b/__tests__/web/basic.test.ts
@@ -1,3 +1,4 @@
+import { firestore } from 'firebase'
 import { FirestoreSimpleWeb } from '../../src/'
 import { WebFirestoreTestUtil } from './util'
 
@@ -56,6 +57,138 @@ describe('Basic', () => {
       const docs = await dao.fetchAll()
 
       expect(docs.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  it('add', async () => {
+    const doc = {
+      title: 'add',
+      num: 10,
+    }
+
+    const addedId = await dao.add(doc)
+
+    const fetchedDoc = await dao.fetch(addedId)
+    expect(fetchedDoc).toEqual({
+      id: expect.anything(),
+      title: doc.title,
+      num: doc.num,
+    })
+  })
+
+  it('set', async () => {
+    const addedDoc = await dao.collectionRef.add({
+      title: 'hogehoge',
+      num: 10,
+    })
+    const setDoc = {
+      id: addedDoc.id,
+      title: 'set',
+      num: 20,
+    }
+
+    const setedId = await dao.set(setDoc)
+
+    const fetchedDoc = await dao.fetch(setedId)
+    expect(fetchedDoc).toEqual(setDoc)
+  })
+
+  describe('addOrSet', () => {
+    it('add', async () => {
+      const doc = {
+        title: 'add',
+        num: 10,
+      }
+
+      const addedId = await dao.addOrSet(doc)
+      expect(addedId).toBeTruthy()
+
+      const fetchedAddDoc = await dao.fetch(addedId)
+      expect(fetchedAddDoc).toEqual({
+        id: expect.anything(),
+        title: doc.title,
+        num: doc.num,
+      })
+    })
+
+    it('set', async () => {
+      const docId = 'addOrSet_set'
+      const setDoc = {
+        id: docId,
+        title: 'set',
+        num: 10,
+      }
+      const setedId = await dao.addOrSet(setDoc)
+      expect(setedId).toEqual(docId)
+
+      const fetchedSetDoc = await dao.fetch(docId)
+      expect(fetchedSetDoc).toEqual(setDoc)
+    })
+  })
+
+  it('delete', async () => {
+    const doc = {
+      title: 'delete',
+      num: 10,
+    }
+    const addedId = await dao.add(doc)
+
+    await dao.delete(addedId)
+    const snapshot = await dao.collectionRef.doc(addedId).get()
+
+    expect(snapshot.exists).toBeFalsy()
+  })
+
+  describe('docRef', () => {
+    it('with no argument should return new document ref', async () => {
+      const docRef = dao.docRef()
+
+      const fetchedDoc = await dao.fetch(docRef.id)
+      expect(fetchedDoc).toBeUndefined()
+    })
+
+    it('with id argument should return exists document ref', async () => {
+      const docRef = dao.docRef(existsDocId)
+
+      const fetchedDoc = await dao.fetch(docRef.id)
+      expect(fetchedDoc).not.toBeUndefined()
+    })
+  })
+
+  describe('update', () => {
+    it('with simple value', async () => {
+      const addedDoc = await dao.collectionRef.add({
+        title: 'hogehoge',
+        num: 10,
+      })
+
+      const expectTitle = 'update'
+      const updatedId = await dao.update({
+        id: addedDoc.id,
+        title: expectTitle,
+      })
+
+      expect(updatedId).toEqual(addedDoc.id)
+
+      const fetchedDoc = await dao.fetch(updatedId)
+      expect(fetchedDoc!.title).toEqual(expectTitle)
+    })
+
+    it('with FieldValue.increment', async () => {
+      const baseNum = 10
+      const addedDoc = await dao.collectionRef.add({
+        title: 'FieldValue_increment',
+        num: baseNum,
+      })
+
+      const incrementNum = 100
+      const updatedId = await dao.update({
+        id: addedDoc.id,
+        num: firestore.FieldValue.increment(incrementNum)
+      })
+
+      const fetchedDoc = await dao.fetch(updatedId)
+      expect(fetchedDoc!.num).toEqual(baseNum + incrementNum)
     })
   })
 })

--- a/__tests__/web/basic.test.ts
+++ b/__tests__/web/basic.test.ts
@@ -1,0 +1,56 @@
+import { WebFirestoreTestUtil } from './util'
+
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const adminFirestore = util.adminFirestore
+const collectionPath = 'basic'
+
+describe('Basic', () => {
+  const existsDocId = 'test'
+  const existsDoc = {
+    title: 'title',
+    num: 10,
+  }
+  // Add fix id document and random id document
+  beforeEach(async () => {
+    await adminFirestore.collection(collectionPath).doc(existsDocId).set(existsDoc)
+    await adminFirestore.collection(collectionPath).add({
+      title: 'before',
+      num: 10,
+    })
+  })
+
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  describe('fetch', () => {
+    it('exists document', async () => {
+      const snapshot = await webFirestore.collection(collectionPath).doc(existsDocId).get()
+      // const doc = await dao.fetch(existsDocId)
+      // const expectDoc = { ...existsDoc, ...{ id: existsDocId } }
+
+      // expect(doc).toEqual(expectDoc)
+      expect(snapshot.data()).toEqual(existsDoc)
+    })
+
+    it('does not exist document', async () => {
+      // const doc = await dao.fetch('not_exists_document_id')
+      const snapshot = await webFirestore.collection(collectionPath).doc('not_exists_document_id').get()
+
+      // expect(doc).toEqual(undefined)
+      expect(snapshot.exists).toBeFalsy()
+    })
+
+    it('fetchAll', async () => {
+      // const docs = await dao.fetchAll()
+      const docs = await (await webFirestore.collection(collectionPath).get()).docs
+
+      expect(docs.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+})

--- a/__tests__/web/basic.test.ts
+++ b/__tests__/web/basic.test.ts
@@ -1,3 +1,4 @@
+import { FirestoreSimpleWeb } from '../../src/'
 import { WebFirestoreTestUtil } from './util'
 
 const util = new WebFirestoreTestUtil()
@@ -5,7 +6,16 @@ const webFirestore = util.webFirestore
 const adminFirestore = util.adminFirestore
 const collectionPath = 'basic'
 
+type TestDoc = {
+  id: string,
+  title: string,
+  num: number,
+}
+
+const firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+
 describe('Basic', () => {
+  const dao = firestoreSimple.collection<TestDoc>({ path: collectionPath })
   const existsDocId = 'test'
   const existsDoc = {
     title: 'title',
@@ -30,25 +40,20 @@ describe('Basic', () => {
 
   describe('fetch', () => {
     it('exists document', async () => {
-      const snapshot = await webFirestore.collection(collectionPath).doc(existsDocId).get()
-      // const doc = await dao.fetch(existsDocId)
-      // const expectDoc = { ...existsDoc, ...{ id: existsDocId } }
+      const doc = await dao.fetch(existsDocId)
+      const expectDoc = { ...existsDoc, ...{ id: existsDocId } }
 
-      // expect(doc).toEqual(expectDoc)
-      expect(snapshot.data()).toEqual(existsDoc)
+      expect(doc).toEqual(expectDoc)
     })
 
     it('does not exist document', async () => {
-      // const doc = await dao.fetch('not_exists_document_id')
-      const snapshot = await webFirestore.collection(collectionPath).doc('not_exists_document_id').get()
+      const doc = await dao.fetch('not_exists_document_id')
 
-      // expect(doc).toEqual(undefined)
-      expect(snapshot.exists).toBeFalsy()
+      expect(doc).toEqual(undefined)
     })
 
     it('fetchAll', async () => {
-      // const docs = await dao.fetchAll()
-      const docs = await (await webFirestore.collection(collectionPath).get()).docs
+      const docs = await dao.fetchAll()
 
       expect(docs.length).toBeGreaterThanOrEqual(2)
     })

--- a/__tests__/web/batch.test.ts
+++ b/__tests__/web/batch.test.ts
@@ -1,0 +1,68 @@
+import { FirestoreSimpleWeb } from '../../src'
+import { WebFirestoreTestUtil } from './util'
+
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const collectionPath = 'abtch'
+
+type TestDoc = {
+  id: string,
+  title: string,
+}
+
+const firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+
+describe('batch', () => {
+  const dao = firestoreSimple.collection<TestDoc>({ path: collectionPath })
+
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  it('bulkAdd', async () => {
+    const docs = [
+      { title: 'aaa' },
+      { title: 'bbb' },
+      { title: 'ccc' },
+    ]
+    await dao.bulkAdd(docs)
+    const fetchedDocs = await dao.fetchAll()
+
+    const actualTitles = fetchedDocs.map((doc) => doc.title).sort()
+    const expectTitles = docs.map((doc) => doc.title).sort()
+    expect(actualTitles).toEqual(expectTitles)
+  })
+
+  it('bulkSet', async () => {
+    const docs = [
+      { id: 'test1', title: 'aaa' },
+      { id: 'test2', title: 'bbb' },
+      { id: 'test3', title: 'ccc' },
+    ]
+    await dao.bulkSet(docs)
+
+    const actualDocs = await dao.fetchAll()
+    expect(actualDocs).toEqual(docs)
+  })
+
+  it('bulkDelete', async () => {
+    const docs = [
+      { id: 'test1', title: 'aaa' },
+      { id: 'test2', title: 'bbb' },
+      { id: 'test3', title: 'ccc' },
+    ]
+    await dao.set(docs[0])
+    await dao.set(docs[1])
+    await dao.set(docs[2])
+
+    const docIds = docs.map((doc) => doc.id)
+    await dao.bulkDelete(docIds)
+
+    const actualDocs = await dao.fetchAll()
+    expect(actualDocs).toEqual([])
+  })
+})

--- a/__tests__/web/collection_group.test.ts
+++ b/__tests__/web/collection_group.test.ts
@@ -1,0 +1,50 @@
+import { FirestoreSimpleWeb } from '../../src'
+import { WebFirestoreTestUtil } from './util'
+
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const collectionPath = 'collection_group'
+
+type TestDoc = {
+  id: string,
+  title: string,
+}
+
+const expectTitles = ['aaa', 'bbb', 'ccc', 'ddd']
+const collectionId = 'collection_group'
+
+const firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+
+describe('collectionGroup', () => {
+  beforeEach(async () => {
+    await webFirestore.collection(`${collectionPath}/1/${collectionId}`).add({ title: expectTitles[0] })
+    await webFirestore.collection(`${collectionPath}/1/${collectionId}`).add({ title: expectTitles[1] })
+    await webFirestore.collection(`${collectionPath}/2/${collectionId}`).add({ title: expectTitles[2] })
+    await webFirestore.collection(`${collectionPath}/3/${collectionId}`).add({ title: expectTitles[3] })
+  })
+
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  it('fetch', async () => {
+    const query = firestoreSimple.collectionGroup<TestDoc>({ collectionId })
+    const docs = await query.fetch()
+
+    const actualTitles = docs.map((doc) => doc.title).sort()
+    expect(actualTitles).toEqual(expectTitles)
+  })
+
+  it('where', async () => {
+    const expectTitle = 'aaa'
+    const query = firestoreSimple.collectionGroup<TestDoc>({ collectionId })
+    const docs = await query.where('title', '==', 'aaa').fetch()
+
+    const actualTitles = docs.map((doc) => doc.title)
+    expect(actualTitles).toEqual([expectTitle])
+  })
+})

--- a/__tests__/web/decode.test.ts
+++ b/__tests__/web/decode.test.ts
@@ -50,17 +50,17 @@ describe('decode', () => {
       expect(fetchedDoc).toEqual({ id: docRef.id, bookTitle: title })
     })
 
-    // it('where with decode', async () => {
-    //   const title = 'add2'
-    //   const docRef = await dao.collectionRef.add({
-    //     book_title: title,
-    //   })
+    it('where with decode', async () => {
+      const title = 'add2'
+      const docRef = await dao.collectionRef.add({
+        book_title: title,
+      })
 
-    //   const fetchedDoc = await dao.where('book_title', '==', title).fetch()
-    //   expect(fetchedDoc).toEqual([
-    //     { id: docRef.id, bookTitle: title }
-    //   ])
-    // })
+      const fetchedDoc = await dao.where('book_title', '==', title).fetch()
+      expect(fetchedDoc).toEqual([
+        { id: docRef.id, bookTitle: title }
+      ])
+    })
   })
 
   describe('to class instance with same key', () => {

--- a/__tests__/web/decode.test.ts
+++ b/__tests__/web/decode.test.ts
@@ -1,0 +1,84 @@
+import { FirestoreSimpleWeb } from '../../src'
+import { WebFirestoreTestUtil } from './util'
+
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const collectionPath = 'decode'
+
+type Book = {
+  id: string,
+  bookTitle: string,
+}
+
+type BookDoc = {
+  book_title: string,
+}
+
+class BookClass {
+  constructor (public id: string, public bookTitle: string) { }
+}
+
+const firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+
+describe('decode', () => {
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  describe('to object with different key', () => {
+    const dao = firestoreSimple.collection<Book, BookDoc>({
+      path: collectionPath,
+      decode: (doc) => {
+        return {
+          id: doc.id,
+          bookTitle: doc.book_title,
+        }
+      },
+    })
+
+    it('fetch with decode', async () => {
+      const title = 'add1'
+      const docRef = await dao.collectionRef.add({
+        book_title: title,
+      })
+
+      const fetchedDoc = await dao.fetch(docRef.id)
+      expect(fetchedDoc).toEqual({ id: docRef.id, bookTitle: title })
+    })
+
+    // it('where with decode', async () => {
+    //   const title = 'add2'
+    //   const docRef = await dao.collectionRef.add({
+    //     book_title: title,
+    //   })
+
+    //   const fetchedDoc = await dao.where('book_title', '==', title).fetch()
+    //   expect(fetchedDoc).toEqual([
+    //     { id: docRef.id, bookTitle: title }
+    //   ])
+    // })
+  })
+
+  describe('to class instance with same key', () => {
+    const dao = firestoreSimple.collection<BookClass>({
+      path: collectionPath,
+      decode: (doc) => {
+        return new BookClass(doc.id, doc.bookTitle)
+      },
+    })
+
+    it('fetch with decode', async () => {
+      const title = 'add1'
+      const docRef = await dao.collectionRef.add({
+        bookTitle: title,
+      })
+
+      const fetchedDoc = await dao.fetch(docRef.id)
+      expect(fetchedDoc).toStrictEqual(new BookClass(docRef.id, title))
+    })
+  })
+})

--- a/__tests__/web/encode.test.ts
+++ b/__tests__/web/encode.test.ts
@@ -1,0 +1,90 @@
+import { FirestoreSimpleWeb } from '../../src'
+import { WebFirestoreTestUtil } from './util'
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const collectionPath = 'encode'
+
+type Book = {
+  id: string,
+  bookTitle: string,
+}
+
+type BookDoc = {
+  book_title: string,
+}
+
+class BookClass {
+  constructor (public id: string, public bookTitle: string) { }
+}
+
+const firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+
+describe('encode', () => {
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  describe('from object with different key', () => {
+    const dao = firestoreSimple.collection<Book, BookDoc>({
+      path: collectionPath,
+      encode: (book) => {
+        return {
+          book_title: book.bookTitle,
+        }
+      },
+    })
+
+    it('add with encode', async () => {
+      const title = 'add'
+      const doc = {
+        bookTitle: title,
+      }
+      const addedId = await dao.add(doc)
+
+      const fetchedDoc = await dao.collectionRef.doc(addedId).get()
+      expect(fetchedDoc.data()).toEqual({ book_title: title })
+    })
+
+    it('set with encode', async () => {
+      const exsitDoc = await dao.collectionRef.add({
+        book_title: 'hogehoge',
+      })
+      const title = 'set'
+      const setDoc = {
+        id: exsitDoc.id,
+        bookTitle: title,
+      }
+      await dao.set(setDoc)
+
+      const fetchedDoc = await dao.collectionRef.doc(exsitDoc.id).get()
+      expect(fetchedDoc.data()).toEqual({ book_title: title })
+    })
+  })
+
+  describe('from class instance with same key', () => {
+    const dao = firestoreSimple.collection<Book>({
+      path: collectionPath,
+      encode: (book) => {
+        return {
+          bookTitle: book.bookTitle,
+        }
+      },
+    })
+
+    it('set with encode', async () => {
+      const exsitDoc = await dao.collectionRef.add({
+        bookTitle: 'hogehoge',
+      })
+      const title = 'set'
+      const setDoc = new BookClass(exsitDoc.id, title)
+      await dao.set(setDoc)
+
+      const fetchedDoc = await dao.collectionRef.doc(exsitDoc.id).get()
+      expect(fetchedDoc.data()).toEqual({ bookTitle: title })
+    })
+  })
+})

--- a/__tests__/web/encode_decode.test.ts
+++ b/__tests__/web/encode_decode.test.ts
@@ -1,0 +1,95 @@
+import { FirestoreSimpleWeb } from '../../src'
+import { WebFirestoreTestUtil } from './util'
+
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const collectionPath = 'encode_decode'
+
+type Book = {
+  id: string,
+  bookTitle: string,
+  created: Date,
+}
+
+type BookDoc = {
+  book_title: string,
+  created: Date,
+}
+
+const firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+
+describe('encode and decode', () => {
+  const dao = firestoreSimple.collection<Book, BookDoc>({
+    path: collectionPath,
+    encode: (book) => {
+      return {
+        book_title: book.bookTitle,
+        created: book.created,
+      }
+    },
+    decode: (doc) => {
+      return {
+        id: doc.id,
+        bookTitle: doc.book_title,
+        created: doc.created.toDate(), // Firestore timestamp to JS Date
+      }
+    },
+  })
+  const now = new Date()
+
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  it('add with encode/decode', async () => {
+    const doc = {
+      bookTitle: 'add',
+      created: now,
+    }
+    const addedBookId = await dao.add(doc)
+
+    const fetchedBook = await dao.fetch(addedBookId)
+    expect(fetchedBook).toEqual({
+      id: addedBookId,
+      bookTitle: doc.bookTitle,
+      created: doc.created,
+    })
+  })
+
+  it('set with encode/decode', async () => {
+    const doc = {
+      book_title: 'exists_book',
+      created: now,
+    }
+    const docRef = await dao.collectionRef.add(doc)
+
+    const title = 'set'
+    const setBook = {
+      id: docRef.id,
+      created: doc.created,
+      bookTitle: title,
+    }
+    await dao.set(setBook)
+
+    const fetchedBook = await dao.fetch(setBook.id)
+    expect(fetchedBook).toEqual(setBook)
+  })
+
+  it('update with encode/decode accept "encoded" key name', async () => {
+    const doc = {
+      book_title: 'exists_book',
+      created: now,
+    }
+    const docRef = await dao.collectionRef.add(doc)
+
+    const updatedTitle = 'update'
+    await dao.update({ id: docRef.id, book_title: updatedTitle })
+
+    const fetchedBook = await dao.fetch(docRef.id)
+    expect(fetchedBook!.bookTitle).toEqual(updatedTitle)
+  })
+})

--- a/__tests__/web/factory_subcollection.test.ts
+++ b/__tests__/web/factory_subcollection.test.ts
@@ -1,0 +1,104 @@
+import { FirestoreSimpleWeb } from '../../src'
+import { WebCollection } from '../../src/web/collection'
+import { Encodable, Decodable } from '../../src/web/types'
+import { WebFirestoreTestUtil } from './util'
+
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const collectionPath = 'factory_subcollection'
+
+type Book = {
+  id: string,
+  title: string,
+  createdAt: Date,
+}
+
+type BookDoc = {
+  title: string,
+  created_at: Date,
+}
+
+const firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+
+describe('Factory and Subcollection', () => {
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  const encodeFunc: Encodable<Book, BookDoc> = (obj) => {
+    return {
+      title: obj.title,
+      created_at: obj.createdAt,
+    }
+  }
+  const decodeFunc: Decodable<Book, BookDoc> = (doc) => {
+    return {
+      id: doc.id,
+      title: doc.title,
+      createdAt: doc.created_at.toDate() // Firestore timestamp to JS Date
+    }
+  }
+
+  describe('FirestoreSimple.collectionFactory', () => {
+    it('should has same encode function', async () => {
+      const factory = firestoreSimple.collectionFactory<Book, BookDoc>({
+        encode: encodeFunc,
+      })
+
+      expect(factory.encode).toBe(encodeFunc)
+    })
+
+    it('should has same decode function', async () => {
+      const factory = firestoreSimple.collectionFactory<Book, BookDoc>({
+        decode: decodeFunc,
+      })
+
+      expect(factory.decode).toBe(decodeFunc)
+    })
+  })
+
+  describe('FirestoreSimpleCollectionFactory.create', () => {
+    const subcollectionPath = `${collectionPath}/test1/sub`
+    const factory = firestoreSimple.collectionFactory<Book, BookDoc>({
+      encode: encodeFunc,
+      decode: decodeFunc,
+    })
+    let dao: WebCollection<Book, BookDoc>
+
+    beforeEach(async () => {
+      dao = factory.create(subcollectionPath)
+    })
+
+    it('should be same collection path', async () => {
+      expect(dao.collectionRef.path).toEqual(subcollectionPath)
+    })
+
+    it('should has same context', async () => {
+      expect(dao.context).toBe(firestoreSimple.context)
+    })
+
+    it('set with encode/decode by created dao', async () => {
+      const now = new Date()
+      const doc = {
+        title: 'exists_book',
+        created_at: now,
+      }
+      const docRef = await dao.collectionRef.add(doc)
+
+      const title = 'set'
+      const setBook = {
+        id: docRef.id,
+        title: title,
+        createdAt: doc.created_at,
+      }
+      await dao.set(setBook)
+
+      const fetchedBook = await dao.fetch(setBook.id)
+      expect(fetchedBook).toEqual(setBook)
+    })
+  })
+})

--- a/__tests__/web/factory_subcollection.test.ts
+++ b/__tests__/web/factory_subcollection.test.ts
@@ -1,6 +1,4 @@
-import { FirestoreSimpleWeb } from '../../src'
-import { WebCollection } from '../../src/web/collection'
-import { Encodable, Decodable } from '../../src/web/types'
+import { FirestoreSimpleWeb, WebCollection, WebEncodable, WebDecodable } from '../../src'
 import { WebFirestoreTestUtil } from './util'
 
 const util = new WebFirestoreTestUtil()
@@ -29,13 +27,13 @@ describe('Factory and Subcollection', () => {
     await util.clearFirestoreData()
   })
 
-  const encodeFunc: Encodable<Book, BookDoc> = (obj) => {
+  const encodeFunc: WebEncodable<Book, BookDoc> = (obj) => {
     return {
       title: obj.title,
       created_at: obj.createdAt,
     }
   }
-  const decodeFunc: Decodable<Book, BookDoc> = (doc) => {
+  const decodeFunc: WebDecodable<Book, BookDoc> = (doc) => {
     return {
       id: doc.id,
       title: doc.title,

--- a/__tests__/web/on_snapshot.test.ts
+++ b/__tests__/web/on_snapshot.test.ts
@@ -1,0 +1,142 @@
+import { FirestoreSimpleWeb } from '../../src'
+import { WebFirestoreTestUtil } from './util'
+
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const collectionPath = 'on_snapshot'
+
+type Book = {
+  id: string,
+  bookTitle: string,
+  created: Date,
+}
+
+type BookDoc = {
+  book_title: string,
+  created: Date,
+}
+
+const firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+
+// Skip reason: Sometimes real Firestore is unstable so it will be replaced emulator test.
+describe.skip('on_snapshot test', () => {
+  const dao = firestoreSimple.collection<Book, BookDoc>({
+    path: collectionPath,
+    encode: (book) => {
+      return {
+        book_title: book.bookTitle,
+        created: book.created,
+      }
+    },
+    decode: (doc) => {
+      return {
+        id: doc.id,
+        bookTitle: doc.book_title,
+        created: doc.created.toDate(), // Firestore timestamp to JS Date
+      }
+    },
+  })
+  let existsDoc: Book
+
+  beforeEach(async () => {
+    const addedDoc = {
+      bookTitle: 'exists',
+      created: new Date(),
+    }
+    const addedId = await dao.add(addedDoc)
+    existsDoc = {
+      ...addedDoc,
+      id: addedId,
+    }
+  })
+
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  it('observe add change', async () => {
+    const doc = {
+      bookTitle: 'add',
+      created: new Date(),
+    }
+
+    const promise = new Promise((resolve) => {
+      dao.onSnapshot((querySnapshot, toObject) => {
+        querySnapshot.docChanges().forEach((change) => {
+          if (change.type === 'added' && change.doc.data().book_title === doc.bookTitle) {
+            const changedDoc = toObject(change.doc)
+
+            expect(changedDoc).toEqual({
+              ...doc,
+              id: expect.anything()
+            })
+            resolve()
+          }
+        })
+      })
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100)) // for async stability
+    await dao.add(doc)
+    await promise
+  })
+
+  it('observe set changes', async () => {
+    const doc = {
+      ...existsDoc,
+      bookTitle: 'set'
+    }
+
+    const promise = new Promise((resolve) => {
+      dao.onSnapshot((querySnapshot, toObject) => {
+        querySnapshot.docChanges().forEach((change) => {
+          if (change.type === 'modified') {
+            const changedDoc = toObject(change.doc)
+
+            expect(changedDoc).toEqual(doc)
+            resolve()
+          }
+        })
+      })
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100)) // for async stability
+    await dao.set(doc)
+    await promise
+  })
+
+  it('observe delete change', async () => {
+    // prepare specific doc for delete onSnapshot()
+    // because onSnapshot() also triggerd deleteCollection() events and it will be confilict.
+    const deletedDoc = {
+      bookTitle: 'deleted',
+      created: new Date(),
+    }
+    const deletedId = await dao.add(deletedDoc)
+
+    const promise = new Promise((resolve) => {
+      dao.onSnapshot((querySnapshot, toObject) => {
+        querySnapshot.docChanges().forEach((change) => {
+          if (change.type === 'removed' && change.doc.data().book_title === deletedDoc.bookTitle) {
+            const changedDoc = toObject(change.doc)
+
+            expect(changedDoc).toEqual({
+              id: expect.anything(),
+              bookTitle: deletedDoc.bookTitle,
+              created: deletedDoc.created,
+            })
+            resolve()
+          }
+        })
+      })
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100)) // for async stability
+    await dao.delete(deletedId)
+    await promise
+  })
+})

--- a/__tests__/web/pagination.test.ts
+++ b/__tests__/web/pagination.test.ts
@@ -1,0 +1,133 @@
+import { FirestoreSimpleWeb } from '../../src'
+import { WebFirestoreTestUtil } from './util'
+
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const collectionPath = 'pagination'
+
+type TestDoc = {
+  id: string,
+  title: string,
+  order: number,
+}
+
+const firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+
+describe('pagination', () => {
+  const dao = firestoreSimple.collection<TestDoc>({ path: collectionPath })
+
+  beforeEach(async () => {
+    const docs = [
+      { id: '1', title: 'a', order: 1 },
+      { id: '2', title: 'b', order: 2 },
+      { id: '3', title: 'b', order: 3 },
+      { id: '4', title: 'c', order: 4 },
+      { id: '5', title: 'd', order: 5 },
+      { id: '6', title: 'd', order: 6 },
+      { id: '7', title: 'e', order: 7 },
+    ]
+    for (const doc of docs) {
+      await dao.set(doc)
+    }
+  })
+
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  describe('startAt', () => {
+    it('with field value', async () => {
+      const fetched = await dao.orderBy('title').startAt('b').fetch()
+      const actual = fetched[0]
+
+      expect(actual).toEqual({ id: '2', title: 'b', order: 2 })
+    })
+
+    it('with multiple field values', async () => {
+      const fetched = await dao
+        .orderBy('title').orderBy('order')
+        .startAt('b', 3)
+        .fetch()
+      const actual = fetched[0]
+
+      expect(actual).toEqual({ id: '3', title: 'b', order: 3 })
+    })
+
+    it('with DocumentSnapshot', async () => {
+      const snapshot = await dao.docRef('3').get()
+      const fetched = await dao.orderBy('title').startAt(snapshot).fetch()
+      const actual = fetched[0]
+
+      expect(actual).toEqual({ id: '3', title: 'b', order: 3 })
+    })
+  })
+
+  describe('startAfter', () => {
+    it('with field value', async () => {
+      const fetched = await dao.orderBy('title').startAfter('b').fetch()
+      const actual = fetched[0]
+
+      expect(actual).toEqual({ id: '4', title: 'c', order: 4 })
+    })
+
+    it('with DocumentSnapshot', async () => {
+      const snapshot = await dao.docRef('3').get()
+      const fetched = await dao.orderBy('title').startAfter(snapshot).fetch()
+      const actual = fetched[0]
+
+      expect(actual).toEqual({ id: '4', title: 'c', order: 4 })
+    })
+  })
+
+  describe('endAt', () => {
+    it('with field value', async () => {
+      const fetched = await dao.orderBy('title').endAt('d').fetch()
+      const actual = fetched[fetched.length - 1]
+
+      expect(actual).toEqual({ id: '6', title: 'd', order: 6 })
+    })
+
+    it('with DocumentSnapshot', async () => {
+      const snapshot = await dao.docRef('6').get()
+      const fetched = await dao.orderBy('title').endAt(snapshot).fetch()
+      const actual = fetched[fetched.length - 1]
+
+      expect(actual).toEqual({ id: '6', title: 'd', order: 6 })
+    })
+  })
+
+  describe('endBefore', () => {
+    it('with field value', async () => {
+      const fetched = await dao.orderBy('title').endBefore('e').fetch()
+      const actual = fetched[fetched.length - 1]
+
+      expect(actual).toEqual({ id: '6', title: 'd', order: 6 })
+    })
+
+    it('with DocumentSnapshot', async () => {
+      const snapshot = await dao.docRef('7').get()
+      const fetched = await dao.orderBy('title').endBefore(snapshot).fetch()
+      const actual = fetched[fetched.length - 1]
+
+      expect(actual).toEqual({ id: '6', title: 'd', order: 6 })
+    })
+  })
+
+  describe('startAfter + endAt', () => {
+    it('with field value', async () => {
+      const fetched = await dao.orderBy('title')
+        .startAfter('b')
+        .endAt('d')
+        .fetch()
+      const actualFirst = fetched[0]
+      const actualLast = fetched[fetched.length - 1]
+
+      expect(actualFirst).toEqual({ id: '4', title: 'c', order: 4 })
+      expect(actualLast).toEqual({ id: '6', title: 'd', order: 6 })
+    })
+  })
+})

--- a/__tests__/web/query.test.ts
+++ b/__tests__/web/query.test.ts
@@ -1,0 +1,95 @@
+import { FirestoreSimpleWeb } from '../../src'
+import { WebFirestoreTestUtil } from './util'
+
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const collectionPath = 'query'
+
+type TestDoc = {
+  id: string,
+  title: string,
+  order: number,
+}
+
+const firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+
+describe('query', () => {
+  const dao = firestoreSimple.collection<TestDoc>({ path: collectionPath })
+
+  beforeEach(async () => {
+    await dao.collectionRef.add({ title: 'aaa', order: 2 })
+    await dao.collectionRef.add({ title: 'aaa', order: 1 })
+    await dao.collectionRef.add({ title: 'bbb', order: 3 })
+    await dao.collectionRef.add({ title: 'ccc', order: 4 })
+  })
+
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  it('where ==', async () => {
+    const queryTitle = 'aaa'
+    const docs = await dao.where('title', '==', queryTitle).fetch()
+
+    const actualTitles = docs.map((doc) => doc.title)
+    expect(actualTitles).toEqual([queryTitle, queryTitle])
+  })
+
+  it('order by desc', async () => {
+    const docs = await dao.orderBy('order', 'desc').fetch()
+
+    const actualOrders = docs.map((doc) => doc.order)
+    expect(actualOrders).toEqual([4, 3, 2, 1])
+  })
+
+  it('limit', async () => {
+    const limit = 1
+    const docs = await dao.limit(limit).fetch()
+
+    expect(docs).toHaveLength(limit)
+  })
+
+  describe('composition', () => {
+    it('where + where', async () => {
+      const docs = await dao
+        .where('order', '>', 1)
+        .where('order', '<', 4)
+        .fetch()
+
+      const expectOrders = [2, 3]
+      const actualOrders = docs.map((doc) => doc.order)
+      expect(actualOrders).toEqual(expectOrders)
+    })
+
+    it('where + limit', async () => {
+      const queryTitle = 'aaa'
+      const limit = 1
+      const docs = await dao
+        .where('title', '==', queryTitle)
+        .limit(limit)
+        .fetch()
+
+      expect(docs).toHaveLength(limit)
+
+      const doc = docs[0]
+      expect(doc.title).toBe(queryTitle)
+    })
+
+    it('order + limit', async () => {
+      const limit = 2
+      const docs = await dao
+        .orderBy('order')
+        .limit(limit)
+        .fetch()
+
+      expect(docs).toHaveLength(limit)
+
+      const actualOrders = docs.map((doc) => doc.order)
+      expect(actualOrders).toEqual([1, 2])
+    })
+  })
+})

--- a/__tests__/web/query_on_snapshot.test.ts
+++ b/__tests__/web/query_on_snapshot.test.ts
@@ -1,0 +1,139 @@
+import { FirestoreSimpleWeb } from '../../src'
+import { WebFirestoreTestUtil } from './util'
+
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const collectionPath = 'query_on_snapshot'
+
+type Book = {
+  id: string,
+  bookTitle: string,
+  created: Date,
+  bookId: number,
+}
+
+type BookDoc = {
+  book_title: string,
+  created: Date,
+  book_id: number,
+}
+
+const firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+
+describe('query on_snapshot test', () => {
+  const dao = firestoreSimple.collection<Book, BookDoc>({
+    path: collectionPath,
+    encode: (book) => {
+      return {
+        book_title: book.bookTitle,
+        created: book.created,
+        book_id: book.bookId,
+      }
+    },
+    decode: (doc) => {
+      return {
+        id: doc.id,
+        bookTitle: doc.book_title,
+        created: doc.created.toDate(), // Firestore timestamp to JS Date
+        bookId: doc.book_id,
+      }
+    },
+  })
+  let existsDoc: Book
+
+  beforeEach(async () => {
+    const addedDoc = {
+      bookTitle: 'exists',
+      created: new Date(),
+      bookId: 1,
+    }
+    const addedId = await dao.add(addedDoc)
+    existsDoc = {
+      ...addedDoc,
+      id: addedId,
+    }
+  })
+
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  it('observe add change', async () => {
+    const doc = {
+      bookTitle: 'query_add',
+      created: new Date(),
+      bookId: 2
+    }
+
+    const promise = new Promise((resolve) => {
+      dao.where('book_id', '==', doc.bookId)
+        .onSnapshot((querySnapshot, toObject) => {
+          querySnapshot.docChanges().forEach((change) => {
+            if (change.type === 'added') {
+              const changedDoc = toObject(change.doc)
+
+              expect(changedDoc).toEqual({
+                ...doc,
+                id: expect.anything(),
+              })
+              resolve()
+            }
+          })
+        })
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100)) // for async stability
+    await dao.add(doc)
+    await promise
+  })
+
+  it('observe set changes', async () => {
+    const doc = {
+      ...existsDoc!,
+      bookTitle: 'query_set',
+    }
+
+    const promise = new Promise((resolve) => {
+      // where('book_title', '==', existsDoc) is not triggered modify existsDoc.
+      // I don't know why, so book_id is hack for resolve this issue.
+      dao.where('book_id', '==', 1)
+        .onSnapshot((querySnapshot, toObject) => {
+          querySnapshot.docChanges().forEach((change) => {
+            if (change.type === 'modified') {
+              const changedDoc = toObject(change.doc)
+
+              expect(changedDoc).toEqual(doc)
+              resolve()
+            }
+          })
+        })
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100)) // for async stability
+    await dao.set(doc)
+    await promise
+  })
+
+  it('observe delete change', async () => {
+    const promise = new Promise((resolve) => {
+      dao.where('book_title', '==', existsDoc.bookTitle).onSnapshot((querySnapshot, toObject) => {
+        querySnapshot.docChanges().forEach((change) => {
+          if (change.type === 'removed' && change.doc.data().book_title === existsDoc.bookTitle) {
+            const changedDoc = toObject(change.doc)
+
+            expect(changedDoc).toEqual(existsDoc)
+            resolve()
+          }
+        })
+      })
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100)) // for async stability
+    await dao.delete(existsDoc.id)
+    await promise
+  })
+})

--- a/__tests__/web/run_batch.test.ts
+++ b/__tests__/web/run_batch.test.ts
@@ -1,0 +1,206 @@
+import { FirestoreSimpleWeb } from '../../src'
+import {} from '../../src/admin/collection'
+import { WebFirestoreTestUtil } from './util'
+import { WebCollection } from '../../src/web/collection'
+
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const collectionPath = 'run_batch'
+const anotherCollectionPath = 'run_batch_another'
+
+type TestDoc = {
+  id: string,
+  title: string,
+}
+
+describe('runBatch', () => {
+  let firestoreSimple: FirestoreSimpleWeb
+  let dao: WebCollection<TestDoc>
+
+  beforeEach(async () => {
+    firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+    dao = firestoreSimple.collection<TestDoc>({ path: collectionPath })
+  })
+
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  describe('context.batch', () => {
+    it('should be undefined before runBatch', async () => {
+      expect(firestoreSimple.context.batch).toBeUndefined()
+    })
+
+    it('should be assigned in runBatch', async () => {
+      await firestoreSimple.runBatch(async (batch) => {
+        expect(firestoreSimple.context.batch).toBe(batch)
+      })
+    })
+
+    it('should be undefined after runBatch', async () => {
+      await firestoreSimple.runBatch(async () => {
+        expect(firestoreSimple.context.batch).not.toBeUndefined()
+      })
+
+      expect(firestoreSimple.context.batch).toBeUndefined()
+    })
+
+    it('should be error nesting runBatch', async () => {
+      await firestoreSimple.runBatch(async () => {
+        expect(
+          firestoreSimple.runBatch(async () => { dao.add({ title: 'test' }) })
+        ).rejects.toThrow()
+      })
+    })
+
+    it('should be error transaction in runBatch', async () => {
+      await firestoreSimple.runBatch(async () => {
+        expect(
+          firestoreSimple.runTransaction(async () => { dao.add({ title: 'test' }) })
+        ).rejects.toThrow()
+      })
+    })
+  })
+
+  describe('write method', () => {
+    it('set', async () => {
+      const doc = { id: 'test1', title: 'aaa' }
+      const updatedDoc = { id: 'test1', title: 'bbb' }
+      await dao.set(doc)
+
+      await firestoreSimple.runBatch(async () => {
+        await dao.set(updatedDoc)
+
+        // document has not updated yet
+        const fetchedOutsideBatch = await dao.fetch(doc.id)
+        expect(fetchedOutsideBatch).toEqual(doc)
+      })
+
+      // document has updated outside runBatch
+      const fetched = await dao.fetch(doc.id)
+      expect(fetched).toEqual(updatedDoc)
+    })
+
+    it('delete', async () => {
+      const doc = { id: 'test1', title: 'aaa' }
+      await dao.set(doc)
+
+      await firestoreSimple.runBatch(async () => {
+        await dao.delete(doc.id)
+
+        // document has not deleted yet
+        const fetchedOutsideBatch = await dao.fetch(doc.id)
+        expect(fetchedOutsideBatch).toEqual(doc)
+      })
+
+      // document has deleted outside runBatch
+      const fetched = await dao.fetch(doc.id)
+      expect(fetched).toBeUndefined()
+    })
+
+    it('add', async () => {
+      let newId: string | undefined
+      const doc = { title: 'aaa' }
+
+      await firestoreSimple.runBatch(async () => {
+        newId = await dao.add(doc)
+
+        // document has not added yet
+        const fetchedOutsideBatch = await dao.fetch(newId)
+        expect(fetchedOutsideBatch).toBeUndefined()
+      })
+
+      if (!newId) return
+      // document has added outside runBatch
+      const fetched = await dao.fetch(newId)
+      expect(fetched).not.toBeUndefined()
+    })
+
+    it('update', async () => {
+      const updatedTitle = 'update'
+      const doc = { id: 'test2', title: 'aaa' }
+      await dao.set(doc)
+
+      await firestoreSimple.runBatch(async () => {
+        await dao.update({ id: doc.id, title: updatedTitle })
+
+        // document has not updated yet
+        const fetchedOutsideBatch = await dao.fetch(doc.id)
+        expect(fetchedOutsideBatch!.title).toEqual(doc.title)
+      })
+
+      // document has updated outside runBatch
+      const fetched = await dao.fetch(doc.id)
+      expect(fetched!.title).toEqual(updatedTitle)
+    })
+  })
+
+  describe('Collection.context.batch', () => {
+    let batchAnotherDao: WebCollection<TestDoc>
+
+    beforeEach(async () => {
+      batchAnotherDao = firestoreSimple.collection<TestDoc>({ path: anotherCollectionPath })
+    })
+
+    it('each collections share same batch context', async () => {
+      await firestoreSimple.runBatch(async (batch) => {
+        expect(dao.context.batch).toBe(batch)
+        expect(batchAnotherDao.context.batch).toBe(batch)
+      })
+    })
+
+    it('runBatch enables across each collections', async () => {
+      // it share same contxt.batch
+      const anotherDao = firestoreSimple.collection<TestDoc>({ path: anotherCollectionPath })
+
+      const doc = { id: 'test1', title: 'aaa' }
+      await dao.set(doc)
+      const anotherDoc = { id: 'test1', title: 'another' }
+      await anotherDao.set(anotherDoc)
+
+      const updatedDoc = { id: 'test1', title: 'bbb' }
+      const updatedAnotherDoc = { id: 'test1', title: 'another_bbb' }
+
+      await firestoreSimple.runBatch(async () => {
+        await dao.set(updatedDoc)
+        await batchAnotherDao.set(updatedAnotherDoc)
+
+        // Both documents has not updated yet
+        const fetchedOutsideBatch = await dao.fetch(doc.id)
+        expect(fetchedOutsideBatch).toEqual(doc)
+        const anotherFetchedOutsideBatch = await anotherDao.fetch(anotherDoc.id)
+        expect(anotherFetchedOutsideBatch).toEqual(anotherDoc)
+      })
+
+      // Both documents has updated outside runBatch
+      const fetched = await dao.fetch(doc.id)
+      expect(fetched).toEqual(updatedDoc)
+      const anotherFetched = await anotherDao.fetch(anotherDoc.id)
+      expect(anotherFetched).toEqual(updatedAnotherDoc)
+    })
+
+    it('should be error bulkSet in runBatch', async () => {
+      await firestoreSimple.runBatch(async () => {
+        const doc = [{ id: 'test1', title: 'aaa' }]
+        expect(
+          dao.bulkSet(doc)
+        ).rejects.toThrow()
+      })
+    })
+
+    it('should be error bulkDelete in runBatch', async () => {
+      const doc = { id: 'test1', title: 'aaa' }
+      await dao.set(doc)
+
+      await firestoreSimple.runBatch(async () => {
+        expect(
+          dao.bulkDelete([doc.id])
+        ).rejects.toThrow()
+      })
+    })
+  })
+})

--- a/__tests__/web/transaction.test.ts
+++ b/__tests__/web/transaction.test.ts
@@ -1,0 +1,226 @@
+import { FirestoreSimpleWeb } from '../../src'
+import {} from '../../src/admin/collection'
+import { WebFirestoreTestUtil } from './util'
+import { WebCollection } from '../../src/web/collection'
+
+const util = new WebFirestoreTestUtil()
+const webFirestore = util.webFirestore
+const collectionPath = 'transaction'
+const anotherCollectionPath = 'transaction_another'
+
+type TestDoc = {
+  id: string,
+  title: string,
+}
+
+const firestoreSimple = new FirestoreSimpleWeb(webFirestore)
+
+describe('transaction', () => {
+  let txFirestoreSimple: FirestoreSimpleWeb
+  let txDao: WebCollection<TestDoc>
+  const dao = firestoreSimple.collection<TestDoc>({ path: collectionPath })
+
+  beforeEach(async () => {
+    txFirestoreSimple = new FirestoreSimpleWeb(webFirestore)
+    txDao = txFirestoreSimple.collection<TestDoc>({ path: collectionPath })
+  })
+
+  afterAll(async () => {
+    await util.deleteApps()
+  })
+
+  afterEach(async () => {
+    await util.clearFirestoreData()
+  })
+
+  describe('context.tx', () => {
+    it('should be undefined before transaction', async () => {
+      expect(txFirestoreSimple.context.tx).toBeUndefined()
+    })
+
+    it('should be assigned in transaction', async () => {
+      await txFirestoreSimple.runTransaction(async (tx) => {
+        expect(txFirestoreSimple.context.tx).toBe(tx)
+      })
+    })
+
+    it('should be undefined after transaction', async () => {
+      await txFirestoreSimple.runTransaction(async (_tx) => {
+        expect(txFirestoreSimple.context.tx).not.toBeUndefined()
+      })
+
+      expect(txFirestoreSimple.context.tx).toBeUndefined()
+    })
+
+    it('should be error nesting transaction', async () => {
+      await txFirestoreSimple.runTransaction(async (_tx) => {
+        expect(
+          txFirestoreSimple.runTransaction(async (_tx) => { dao.add({ title: 'test' }) })
+        ).rejects.toThrow()
+      })
+    })
+
+    it('should be error runBatch in transaction', async () => {
+      await txFirestoreSimple.runTransaction(async (_tx) => {
+        expect(
+          txFirestoreSimple.runBatch(async (_batch) => { dao.add({ title: 'test' }) })
+        ).rejects.toThrow()
+      })
+    })
+  })
+
+  describe('Collection', () => {
+    describe('write method', () => {
+      it('set', async () => {
+        const doc = { id: 'test1', title: 'aaa' }
+        const updatedDoc = { id: 'test1', title: 'bbb' }
+        await dao.set(doc)
+
+        await txFirestoreSimple.runTransaction(async () => {
+          await txDao.set(updatedDoc)
+
+          // Set document can't see outside transaction
+          const outTxFetched = await dao.fetch(doc.id)
+          expect(outTxFetched).toEqual(doc)
+        })
+
+        // Set document can see after transaction
+        const fetched = await dao.fetch(doc.id)
+        expect(fetched).toEqual(updatedDoc)
+      })
+
+      it('delete', async () => {
+        const doc = { id: 'test1', title: 'aaa' }
+        await dao.set(doc)
+
+        await txFirestoreSimple.runTransaction(async () => {
+          await txDao.delete(doc.id)
+
+          // Deleted document can't see outside transaction
+          const outTxFetched = await dao.fetch(doc.id)
+          expect(outTxFetched).toEqual(doc)
+        })
+
+        // Deleted document can see after transaction
+        const fetched = await dao.fetch(doc.id)
+        expect(fetched).toBeUndefined()
+      })
+
+      it('add', async () => {
+        let newId: string | undefined
+        const doc = { title: 'aaa' }
+
+        await txFirestoreSimple.runTransaction(async () => {
+          newId = await txDao.add(doc)
+
+          // Added document can't see outside transaction
+          const outTxFetched = await dao.fetch(newId)
+          expect(outTxFetched).toBeUndefined()
+        })
+
+        if (!newId) return
+        // Added document can see after transaction
+        const fetched = await dao.fetch(newId)
+        expect(fetched).not.toBeUndefined()
+      })
+
+      it('update', async () => {
+        const updatedTitle = 'update'
+        const doc = { id: 'test2', title: 'aaa' }
+        await dao.set(doc)
+
+        await txFirestoreSimple.runTransaction(async () => {
+          await txDao.update({ id: doc.id, title: updatedTitle })
+
+          // Updated document can't see outside transaction
+          const outTxFetched = await dao.fetch(doc.id)
+          expect(outTxFetched!.title).toEqual(doc.title)
+        })
+
+        // Updated document can see after transaction
+        const fetched = await dao.fetch(doc.id)
+        expect(fetched!.title).toEqual(updatedTitle)
+      })
+    })
+
+    describe('read method', () => {
+      it('fetch after set in transaction should be error', async () => {
+        const doc = { id: 'test1', title: 'aaa' }
+        const updatedDoc = { id: 'test1', title: 'bbb' }
+        await dao.set(doc)
+
+        await txFirestoreSimple.runTransaction(async () => {
+          await txDao.set(updatedDoc)
+
+          // Firestore throw error READ after WRITE in same transaction.
+          // To show txDao.fetch() is inside transaction, assert transaction error.
+          await expect(txDao.fetch(doc.id)).rejects.toThrow(
+            'Firestore transactions require all reads to be executed before all writes.'
+          )
+        })
+      })
+
+      it('fetchAll should be error', async () => {
+        await txFirestoreSimple.runTransaction(async () => {
+          await expect(txDao.fetchAll()).rejects.toThrow(
+            'Web SDK transaction.get() does not support QuerySnapshot'
+          )
+        })
+      })
+
+      it('query after set in transaction should be error', async () => {
+        await txFirestoreSimple.runTransaction(async () => {
+          await expect(
+            txDao.where('title', '==', 'bbb').fetch()
+          ).rejects.toThrow(
+            'Web SDK transaction.get() does not support QuerySnapshot'
+          )
+        })
+      })
+    })
+  })
+
+  describe('Collection.context.tx', () => {
+    let txAnotherDao: WebCollection<TestDoc>
+
+    beforeEach(async () => {
+      txAnotherDao = txFirestoreSimple.collection<TestDoc>({ path: anotherCollectionPath })
+    })
+
+    it('each collections share same transaction context', async () => {
+      await txFirestoreSimple.runTransaction(async (tx) => {
+        expect(txDao.context.tx).toBe(tx)
+        expect(txAnotherDao.context.tx).toBe(tx)
+      })
+    })
+
+    it('transaction enables across each collections', async () => {
+      const anotherDao = firestoreSimple.collection<TestDoc>({ path: anotherCollectionPath })
+
+      const doc = { id: 'test1', title: 'aaa' }
+      await dao.set(doc)
+      const anotherDoc = { id: 'test1', title: 'another' }
+      await anotherDao.set(anotherDoc)
+
+      const updatedDoc = { id: 'test1', title: 'bbb' }
+      const updatedAnotherDoc = { id: 'test1', title: 'another_bbb' }
+
+      await txFirestoreSimple.runTransaction(async () => {
+        await txDao.set(updatedDoc)
+        await txAnotherDao.set(updatedAnotherDoc)
+
+        // Updated document can't see outside transaction
+        const outTxFetched = await dao.fetch(doc.id)
+        expect(outTxFetched).toEqual(doc)
+        const outTxAnotherFetched = await anotherDao.fetch(anotherDoc.id)
+        expect(outTxAnotherFetched).toEqual(anotherDoc)
+      })
+
+      // Updated document can see after transaction
+      const fetched = await dao.fetch(doc.id)
+      expect(fetched).toEqual(updatedDoc)
+      const anotherFetched = await anotherDao.fetch(anotherDoc.id)
+      expect(anotherFetched).toEqual(updatedAnotherDoc)
+    })
+  })
+})

--- a/__tests__/web/util.ts
+++ b/__tests__/web/util.ts
@@ -1,0 +1,40 @@
+// import fs from 'fs'
+import { Firestore } from '@google-cloud/firestore'
+import * as firebase from '@firebase/testing'
+import crypto from 'crypto'
+
+export class WebFirestoreTestUtil {
+  projectId: string
+  uid: string
+  webFirestore: firebase.firestore.Firestore
+  adminFirestore: Firestore
+
+  constructor () {
+    // Use random projectId to separate emulator firestore namespace for concurrent testing
+    const randomStr = crypto.randomBytes(10).toString('hex')
+    this.projectId = `test-${randomStr}`
+    this.uid = 'test-user'
+
+    // Setup web Firestore and admin Firestore with using emulator
+    this.webFirestore = firebase.initializeTestApp({
+      projectId: this.projectId,
+      auth: { uid: this.uid }
+    }).firestore()
+
+    this.adminFirestore = firebase.initializeAdminApp({
+      projectId: this.projectId
+    }).firestore() as unknown as Firestore
+  }
+
+  // Clear emulator Firestore data
+  // Use in 'afterEach'
+  async clearFirestoreData () {
+    await firebase.clearFirestoreData({ projectId: this.projectId })
+  }
+
+  // Delete firebase listner
+  // Use in 'afterAll'
+  async deleteApps () {
+    await Promise.all(firebase.apps().map(app => app.delete()))
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-simple",
-  "version": "7.0.0-0",
+  "version": "7.0.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -291,16 +291,119 @@
         "minimist": "^1.2.0"
       }
     },
+    "@firebase/analytics": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.2.16.tgz",
+      "integrity": "sha512-t4lwd8SxigKULvt8a+VA1cVj7Aml/tUNECV9vzz3G9wusxDE76d7rTw+HexKTNPRbD2E9+JtRKUVPKlJpox9bw==",
+      "dev": true,
+      "requires": {
+        "@firebase/analytics-types": "0.2.7",
+        "@firebase/component": "0.1.6",
+        "@firebase/installations": "0.4.4",
+        "@firebase/util": "0.2.41",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.6.tgz",
+          "integrity": "sha512-dm5pVhm+sU8ag1M3hY6vleA/H7Ed8sKRxbm4TAKhtjGHDejPXxnK0meTNydJ3MwisHWlwzGuzIEhb223K7FFxA==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.41",
+            "tslib": "1.10.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "0.2.41",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.41.tgz",
+          "integrity": "sha512-QRu3wjU5I0ZBWrf4wgrEBYu5K5tkHjETMDPMY8WYCeekKB13k2MuJzHBjQVuStEOU7j6ygTAA0B8vXI/6B5D0g==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        }
+      }
+    },
+    "@firebase/analytics-types": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.2.7.tgz",
+      "integrity": "sha512-2596a1v62BkVXuobbQerC1gDavoxFOmgVutFFQcm24v6/2Iv8nlx2k8Wjy9eLAZWmAZHU/RkTX11K9gHy+w5Bg==",
+      "dev": true
+    },
+    "@firebase/app": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.5.5.tgz",
+      "integrity": "sha512-CCqX/ZuNkPnyE2jQapVAHpp3Y0cSJZVBQRl+YjcmtfeiCl8WcUb7pyVJZYLPEw5xZZZVJWOrZXO393teiFtsIg==",
+      "dev": true,
+      "requires": {
+        "@firebase/app-types": "0.5.2",
+        "@firebase/component": "0.1.6",
+        "@firebase/logger": "0.1.36",
+        "@firebase/util": "0.2.41",
+        "dom-storage": "2.1.0",
+        "tslib": "1.10.0",
+        "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "@firebase/app-types": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.5.2.tgz",
+          "integrity": "sha512-k3zRi9gXyWrymu8OL6DA1Pz7eo+sKVBopX5ouOjQwozAZ55WhelifPC99WHmLWo8sAokNM0XDyzM7loOA5yliQ==",
+          "dev": true
+        },
+        "@firebase/component": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.6.tgz",
+          "integrity": "sha512-dm5pVhm+sU8ag1M3hY6vleA/H7Ed8sKRxbm4TAKhtjGHDejPXxnK0meTNydJ3MwisHWlwzGuzIEhb223K7FFxA==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.41",
+            "tslib": "1.10.0"
+          }
+        },
+        "@firebase/logger": {
+          "version": "0.1.36",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.36.tgz",
+          "integrity": "sha512-5Z0ryTtzRk7kjUb0/18r10oXYu8mSPAjgdbLowRBP6HdSJB7BDiUIRS7iATSmUBZLTArdroSiFJ29m7YDfm/cw==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.41",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.41.tgz",
+          "integrity": "sha512-QRu3wjU5I0ZBWrf4wgrEBYu5K5tkHjETMDPMY8WYCeekKB13k2MuJzHBjQVuStEOU7j6ygTAA0B8vXI/6B5D0g==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        }
+      }
+    },
     "@firebase/app-types": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.5.0.tgz",
       "integrity": "sha512-8j+vCXTpAkYGcFk86mPZ90V6HMFmn196RIEW9Opi0PN+VrPFC1l/eW0gptM8v7VXaQhECOxws3TN2g+dDaeSYA==",
       "dev": true
     },
+    "@firebase/auth": {
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.13.6.tgz",
+      "integrity": "sha512-ERlda/t5RimNw5Err+5HJATC/qFkC64zR40G+4nK5b9eFJEm0MB+/DaismCwp6J6GoVL3NmejoVbuWU7sV4G1w==",
+      "dev": true,
+      "requires": {
+        "@firebase/auth-types": "0.9.6"
+      }
+    },
     "@firebase/auth-interop-types": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.1.tgz",
       "integrity": "sha512-rNpCOyCspZvNDoQVQLQQgWAGBMB2ClCWKN1c8cEFgLNFgnMJrjVB+tcL7KW2q2UjKa7l8Mxgwys7szTiEDAcvA==",
+      "dev": true
+    },
+    "@firebase/auth-types": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.9.6.tgz",
+      "integrity": "sha512-HB1yXe5hgiwPMukLBEfC3TQX22U9qKczj8kEclKhL7rnds3FKZWMM0+EpKbcJREbU9Sj/rgwgaio7ovSN4ZQFA==",
       "dev": true
     },
     "@firebase/component": {
@@ -337,11 +440,364 @@
         "@firebase/app-types": "0.5.0"
       }
     },
+    "@firebase/firestore": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.12.0.tgz",
+      "integrity": "sha512-GWFU3pPs0xyp2ynFQIyvlmTtg4goGvOkT/lhVCu/Bq6/78xbl395nCPBMjF7IpUl+aVqQVUCwtF/cxrtNXgjMA==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.6",
+        "@firebase/firestore-types": "1.10.0",
+        "@firebase/logger": "0.1.36",
+        "@firebase/util": "0.2.41",
+        "@firebase/webchannel-wrapper": "0.2.36",
+        "@grpc/proto-loader": "^0.5.0",
+        "grpc": "1.24.2",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.6.tgz",
+          "integrity": "sha512-dm5pVhm+sU8ag1M3hY6vleA/H7Ed8sKRxbm4TAKhtjGHDejPXxnK0meTNydJ3MwisHWlwzGuzIEhb223K7FFxA==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.41",
+            "tslib": "1.10.0"
+          }
+        },
+        "@firebase/logger": {
+          "version": "0.1.36",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.36.tgz",
+          "integrity": "sha512-5Z0ryTtzRk7kjUb0/18r10oXYu8mSPAjgdbLowRBP6HdSJB7BDiUIRS7iATSmUBZLTArdroSiFJ29m7YDfm/cw==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.41",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.41.tgz",
+          "integrity": "sha512-QRu3wjU5I0ZBWrf4wgrEBYu5K5tkHjETMDPMY8WYCeekKB13k2MuJzHBjQVuStEOU7j6ygTAA0B8vXI/6B5D0g==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        }
+      }
+    },
+    "@firebase/firestore-types": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.10.0.tgz",
+      "integrity": "sha512-/Pvmu5hpc0pceB96X2mEOAdEB0Xyn6+IQliBl7dUhu23AztnjBq+9uKcsgMB+k34RCApFQfNm1m24E4e+fUSVg==",
+      "dev": true
+    },
+    "@firebase/functions": {
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.36.tgz",
+      "integrity": "sha512-GheZOwxUbMHhM1xidkOJlfTGk4FuC2sJBA9/yYA23St5qgudcT0Bu3r+3XcC4DhJv6G/mu2IoM9dn1LBgBclXw==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.6",
+        "@firebase/functions-types": "0.3.15",
+        "@firebase/messaging-types": "0.4.3",
+        "isomorphic-fetch": "2.2.1",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.6.tgz",
+          "integrity": "sha512-dm5pVhm+sU8ag1M3hY6vleA/H7Ed8sKRxbm4TAKhtjGHDejPXxnK0meTNydJ3MwisHWlwzGuzIEhb223K7FFxA==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.41",
+            "tslib": "1.10.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "0.2.41",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.41.tgz",
+          "integrity": "sha512-QRu3wjU5I0ZBWrf4wgrEBYu5K5tkHjETMDPMY8WYCeekKB13k2MuJzHBjQVuStEOU7j6ygTAA0B8vXI/6B5D0g==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        }
+      }
+    },
+    "@firebase/functions-types": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.15.tgz",
+      "integrity": "sha512-VM0v7fJM+mzvL9tJgNtQWc3UZLUOl2GJYi0TdfiuqTbfEdPDQCXtYVTN3roAO5LJTIgNw0imZyOCgsHDy9MtXg==",
+      "dev": true
+    },
+    "@firebase/installations": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.4.tgz",
+      "integrity": "sha512-gbfK5dOKe1SyveF7Ko7Bg/LtTPoX3cByoGUv7LMR0Q7Dn8Qw9JsIz2n7q21tr2YzAxv1q7RqIzRJchoFicqISA==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.6",
+        "@firebase/installations-types": "0.3.2",
+        "@firebase/util": "0.2.41",
+        "idb": "3.0.2",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.6.tgz",
+          "integrity": "sha512-dm5pVhm+sU8ag1M3hY6vleA/H7Ed8sKRxbm4TAKhtjGHDejPXxnK0meTNydJ3MwisHWlwzGuzIEhb223K7FFxA==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.41",
+            "tslib": "1.10.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "0.2.41",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.41.tgz",
+          "integrity": "sha512-QRu3wjU5I0ZBWrf4wgrEBYu5K5tkHjETMDPMY8WYCeekKB13k2MuJzHBjQVuStEOU7j6ygTAA0B8vXI/6B5D0g==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        }
+      }
+    },
+    "@firebase/installations-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.3.2.tgz",
+      "integrity": "sha512-E5Jp1QlwYSypRiOJSkKtEC2RS8GnubUYqTAqjiJAtBsa0guZZunBcXvdn3kqWOyn3R4HaM2tDZ/bGdWpulVUkg==",
+      "dev": true
+    },
     "@firebase/logger": {
       "version": "0.1.34",
       "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.34.tgz",
       "integrity": "sha512-J2h6ylpd1IcuonRM3HBdXThitds6aQSIeoPYRPvApSFy82NhFPKRzJlflAhlQWjJOh59/jyQBGWJNxCL6fp4hw==",
       "dev": true
+    },
+    "@firebase/messaging": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.6.8.tgz",
+      "integrity": "sha512-APMuLpx2XnYCQMvKI9W17CfNOi+YhecoU5gZLwUuuspZvgasr28daSNNU+QcjdMPsJsIbU9UDJa4do8x2uAEig==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.6",
+        "@firebase/installations": "0.4.4",
+        "@firebase/messaging-types": "0.4.3",
+        "@firebase/util": "0.2.41",
+        "idb": "3.0.2",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.6.tgz",
+          "integrity": "sha512-dm5pVhm+sU8ag1M3hY6vleA/H7Ed8sKRxbm4TAKhtjGHDejPXxnK0meTNydJ3MwisHWlwzGuzIEhb223K7FFxA==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.41",
+            "tslib": "1.10.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "0.2.41",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.41.tgz",
+          "integrity": "sha512-QRu3wjU5I0ZBWrf4wgrEBYu5K5tkHjETMDPMY8WYCeekKB13k2MuJzHBjQVuStEOU7j6ygTAA0B8vXI/6B5D0g==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        }
+      }
+    },
+    "@firebase/messaging-types": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.4.3.tgz",
+      "integrity": "sha512-FxUQXjy5p/5r6E/pGS3Bnp3+3wshh3vkCo7ISU7ggOM6GBhq9FnyBLZKGix7bsjn079sNTOr5PH0KT8wGI+CPQ==",
+      "dev": true
+    },
+    "@firebase/performance": {
+      "version": "0.2.34",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.2.34.tgz",
+      "integrity": "sha512-Ek038Acq0mbVqsw7TGqomFDBxvoTIu1rdRdqRKSdFiBRZcLLW9X1Ad6aSATMu6lki2gcUE/XCbMJtSQfVsl5Bw==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.6",
+        "@firebase/installations": "0.4.4",
+        "@firebase/logger": "0.1.36",
+        "@firebase/performance-types": "0.0.11",
+        "@firebase/util": "0.2.41",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.6.tgz",
+          "integrity": "sha512-dm5pVhm+sU8ag1M3hY6vleA/H7Ed8sKRxbm4TAKhtjGHDejPXxnK0meTNydJ3MwisHWlwzGuzIEhb223K7FFxA==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.41",
+            "tslib": "1.10.0"
+          }
+        },
+        "@firebase/logger": {
+          "version": "0.1.36",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.36.tgz",
+          "integrity": "sha512-5Z0ryTtzRk7kjUb0/18r10oXYu8mSPAjgdbLowRBP6HdSJB7BDiUIRS7iATSmUBZLTArdroSiFJ29m7YDfm/cw==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.41",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.41.tgz",
+          "integrity": "sha512-QRu3wjU5I0ZBWrf4wgrEBYu5K5tkHjETMDPMY8WYCeekKB13k2MuJzHBjQVuStEOU7j6ygTAA0B8vXI/6B5D0g==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        }
+      }
+    },
+    "@firebase/performance-types": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.11.tgz",
+      "integrity": "sha512-w6dD4ZcWT1NsGsPcgX1lAVZyxEVEWgTSBu768YABCQH7zVcvPo9PE3xWcPWPujlAPf9QXdessiX9cC5m4Khabw==",
+      "dev": true
+    },
+    "@firebase/polyfill": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.31.tgz",
+      "integrity": "sha512-7XItMz50tdba57tCOTCSH8REvHYbrTU7MBOksnNZ3td/J9W/RkCPcLVSSnFWNmn0Jv1aufpUevryX1J4DZ/oiw==",
+      "dev": true,
+      "requires": {
+        "core-js": "3.6.2",
+        "promise-polyfill": "8.1.3",
+        "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/remote-config": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.15.tgz",
+      "integrity": "sha512-avBM6w6oLV3fEBVGTXdIBKuj62p4Zcu0/01Xm4YEsdrMRfyLX1Q9C5XYIsGiGb6xM+R8EWzd5F4AsAMtc/ofQw==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.6",
+        "@firebase/installations": "0.4.4",
+        "@firebase/logger": "0.1.36",
+        "@firebase/remote-config-types": "0.1.7",
+        "@firebase/util": "0.2.41",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.6.tgz",
+          "integrity": "sha512-dm5pVhm+sU8ag1M3hY6vleA/H7Ed8sKRxbm4TAKhtjGHDejPXxnK0meTNydJ3MwisHWlwzGuzIEhb223K7FFxA==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.41",
+            "tslib": "1.10.0"
+          }
+        },
+        "@firebase/logger": {
+          "version": "0.1.36",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.36.tgz",
+          "integrity": "sha512-5Z0ryTtzRk7kjUb0/18r10oXYu8mSPAjgdbLowRBP6HdSJB7BDiUIRS7iATSmUBZLTArdroSiFJ29m7YDfm/cw==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.41",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.41.tgz",
+          "integrity": "sha512-QRu3wjU5I0ZBWrf4wgrEBYu5K5tkHjETMDPMY8WYCeekKB13k2MuJzHBjQVuStEOU7j6ygTAA0B8vXI/6B5D0g==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        }
+      }
+    },
+    "@firebase/remote-config-types": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.1.7.tgz",
+      "integrity": "sha512-oWyw1KNx/2+vaNBe1zYSppe5eSmjLxIphi49VAwYWO3SqhxpF3BsJ0uo4f9pU4bjYINuRFMYsCkbhZuKAR7o+w==",
+      "dev": true
+    },
+    "@firebase/storage": {
+      "version": "0.3.28",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.28.tgz",
+      "integrity": "sha512-70GFutKqYBkqN3TCXgd8asGc/i3NYuCpaBvCHk7QpwN+7/9Cukba4GOfiN1QIINc7nOj/nrsWKvo49NzhxGy4w==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.6",
+        "@firebase/storage-types": "0.3.10",
+        "@firebase/util": "0.2.41",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.6.tgz",
+          "integrity": "sha512-dm5pVhm+sU8ag1M3hY6vleA/H7Ed8sKRxbm4TAKhtjGHDejPXxnK0meTNydJ3MwisHWlwzGuzIEhb223K7FFxA==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.41",
+            "tslib": "1.10.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "0.2.41",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.41.tgz",
+          "integrity": "sha512-QRu3wjU5I0ZBWrf4wgrEBYu5K5tkHjETMDPMY8WYCeekKB13k2MuJzHBjQVuStEOU7j6ygTAA0B8vXI/6B5D0g==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        }
+      }
+    },
+    "@firebase/storage-types": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.10.tgz",
+      "integrity": "sha512-c76gnTUFTDDumV4GenkuVY34EwAXjN7ZWLR6NSvuAnMvBlROdGKshTCsmyi8GTMd/dDoFB/MLJ+YOnk5tMbU4Q==",
+      "dev": true
+    },
+    "@firebase/testing": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@firebase/testing/-/testing-0.16.14.tgz",
+      "integrity": "sha512-BzAgfPQVJ+y+kl6w9QLhKspc76m8ZM5oHDX6chWn/6DleeTjumgqPBlZ3+2y9+wguiKnoGK7UeuQ592LEw8kLg==",
+      "dev": true,
+      "requires": {
+        "@firebase/logger": "0.1.36",
+        "@firebase/util": "0.2.41",
+        "@types/request": "2.48.4",
+        "firebase": "7.10.0",
+        "grpc": "1.24.2",
+        "request": "2.88.0"
+      },
+      "dependencies": {
+        "@firebase/logger": {
+          "version": "0.1.36",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.36.tgz",
+          "integrity": "sha512-5Z0ryTtzRk7kjUb0/18r10oXYu8mSPAjgdbLowRBP6HdSJB7BDiUIRS7iATSmUBZLTArdroSiFJ29m7YDfm/cw==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.41",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.41.tgz",
+          "integrity": "sha512-QRu3wjU5I0ZBWrf4wgrEBYu5K5tkHjETMDPMY8WYCeekKB13k2MuJzHBjQVuStEOU7j6ygTAA0B8vXI/6B5D0g==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        }
+      }
     },
     "@firebase/util": {
       "version": "0.2.38",
@@ -351,6 +807,12 @@
       "requires": {
         "tslib": "1.10.0"
       }
+    },
+    "@firebase/webchannel-wrapper": {
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.36.tgz",
+      "integrity": "sha512-Vy7N8674HVHLZtRfZurvxThYeIi4sK1AeiV6DKFfndhGDfC/+iKHidoC/pgFoIIJR8E8tH5QD22Wndb0iW6cxw==",
+      "dev": true
     },
     "@google-cloud/common": {
       "version": "2.2.6",
@@ -508,7 +970,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.3.tgz",
       "integrity": "sha512-8qvUtGg77G2ZT2HqdqYoM/OY97gQd/0crSG34xNmZ4ZOsv3aQT/FQV9QfZPazTGna6MIoyUd+u6AxsoZjJ/VMQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "protobufjs": "^6.8.6"
@@ -1488,36 +1949,31 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
       "dev": true,
-      "optional": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -1527,36 +1983,31 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.7.0",
@@ -1624,6 +2075,22 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/bytebuffer": {
+      "version": "5.0.40",
+      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
+      "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
+      "dev": true,
+      "requires": {
+        "@types/long": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -1709,8 +2176,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -1724,10 +2190,41 @@
       "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==",
       "dev": true
     },
+    "@types/request": {
+      "version": "2.48.4",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.4.tgz",
+      "integrity": "sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.6.tgz",
+      "integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ==",
       "dev": true
     },
     "@types/yargs": {
@@ -2068,6 +2565,16 @@
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true,
       "optional": true
+    },
+    "ascli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+      "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+      "dev": true,
+      "requires": {
+        "colour": "~0.7.1",
+        "optjs": "~3.2.2"
+      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -2421,6 +2928,23 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "bytebuffer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+      "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+      "dev": true,
+      "requires": {
+        "long": "~3"
+      },
+      "dependencies": {
+        "long": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+          "dev": true
+        }
+      }
+    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -2677,6 +3201,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colour": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=",
       "dev": true
     },
     "combined-stream": {
@@ -3051,6 +3581,12 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.2.tgz",
+      "integrity": "sha512-hIE5dXkRzRvnZ5vhkRfQxUvDxQZmD9oueA08jDYRBKJHx+VIl/Pne/e0A4x9LObEEthC/TqiZybUoNM4tRgnKg==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3400,6 +3936,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-storage": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
+      "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
+      "dev": true
+    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -3503,6 +4045,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -4456,6 +5007,91 @@
         }
       }
     },
+    "firebase": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.10.0.tgz",
+      "integrity": "sha512-j80k8wsgg0N/t8uOkpGK6OT1MHHZ3Y/98nyZJJ+6lNodA6O79mXgyvI4AwXlPYd8qfmYeXwHz1f19sC+EqnZZg==",
+      "dev": true,
+      "requires": {
+        "@firebase/analytics": "0.2.16",
+        "@firebase/app": "0.5.5",
+        "@firebase/app-types": "0.5.2",
+        "@firebase/auth": "0.13.6",
+        "@firebase/database": "0.5.22",
+        "@firebase/firestore": "1.12.0",
+        "@firebase/functions": "0.4.36",
+        "@firebase/installations": "0.4.4",
+        "@firebase/messaging": "0.6.8",
+        "@firebase/performance": "0.2.34",
+        "@firebase/polyfill": "0.3.31",
+        "@firebase/remote-config": "0.1.15",
+        "@firebase/storage": "0.3.28",
+        "@firebase/util": "0.2.41"
+      },
+      "dependencies": {
+        "@firebase/app-types": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.5.2.tgz",
+          "integrity": "sha512-k3zRi9gXyWrymu8OL6DA1Pz7eo+sKVBopX5ouOjQwozAZ55WhelifPC99WHmLWo8sAokNM0XDyzM7loOA5yliQ==",
+          "dev": true
+        },
+        "@firebase/auth-interop-types": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.3.tgz",
+          "integrity": "sha512-Fd0MJ8hHw/MasNTJz7vl5jnMMs71X6pY/VqN0V6lqdP5HKTuyPVnffJ1d2Vb6uCLZ1D7nXAer4YWj9cOrNLPAQ==",
+          "dev": true
+        },
+        "@firebase/component": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.6.tgz",
+          "integrity": "sha512-dm5pVhm+sU8ag1M3hY6vleA/H7Ed8sKRxbm4TAKhtjGHDejPXxnK0meTNydJ3MwisHWlwzGuzIEhb223K7FFxA==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.41",
+            "tslib": "1.10.0"
+          }
+        },
+        "@firebase/database": {
+          "version": "0.5.22",
+          "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.5.22.tgz",
+          "integrity": "sha512-3CVsmLFscFIAFOjjVhlT6HzFOhS0TKVbjhixp64oVZMOshp9qPHtHIytf6QXRAypbtZMPFAMGnhNu0pmPW/vtg==",
+          "dev": true,
+          "requires": {
+            "@firebase/auth-interop-types": "0.1.3",
+            "@firebase/component": "0.1.6",
+            "@firebase/database-types": "0.4.12",
+            "@firebase/logger": "0.1.36",
+            "@firebase/util": "0.2.41",
+            "faye-websocket": "0.11.3",
+            "tslib": "1.10.0"
+          }
+        },
+        "@firebase/database-types": {
+          "version": "0.4.12",
+          "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.4.12.tgz",
+          "integrity": "sha512-PVCTQRG9fnN1cam3Qr91+WzsCf9tO+lmUcPEb0uvafSFVhvx2U9OZOlYDdM5hS0MMHTNXI7Ywmc33EheIlLmMw==",
+          "dev": true,
+          "requires": {
+            "@firebase/app-types": "0.5.2"
+          }
+        },
+        "@firebase/logger": {
+          "version": "0.1.36",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.36.tgz",
+          "integrity": "sha512-5Z0ryTtzRk7kjUb0/18r10oXYu8mSPAjgdbLowRBP6HdSJB7BDiUIRS7iATSmUBZLTArdroSiFJ29m7YDfm/cw==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.41",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.41.tgz",
+          "integrity": "sha512-QRu3wjU5I0ZBWrf4wgrEBYu5K5tkHjETMDPMY8WYCeekKB13k2MuJzHBjQVuStEOU7j6ygTAA0B8vXI/6B5D0g==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        }
+      }
+    },
     "firebase-admin": {
       "version": "8.9.2",
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-8.9.2.tgz",
@@ -5212,6 +5848,551 @@
       "dev": true,
       "optional": true
     },
+    "grpc": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
+      "integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
+      "dev": true,
+      "requires": {
+        "@types/bytebuffer": "^5.0.40",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.clone": "^4.5.0",
+        "nan": "^2.13.2",
+        "node-pre-gyp": "^0.14.0",
+        "protobufjs": "^5.0.3"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "chownr": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "debug": {
+          "version": "3.2.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "fs-minipass": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^2.6.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^2.9.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "needle": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^3.2.6",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.14.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4.4.2"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-packlist": {
+          "version": "1.4.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "protobufjs": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+          "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+          "dev": true,
+          "requires": {
+            "ascli": "~1",
+            "bytebuffer": "~5",
+            "glob": "^7.0.5",
+            "yargs": "^3.10.0"
+          }
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "tar": {
+          "version": "4.4.13",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
+        }
+      }
+    },
     "gtoken": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
@@ -5492,6 +6673,12 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "idb": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
+      "integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
+      "dev": true
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -5645,6 +6832,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "ip-regex": {
@@ -5969,6 +7162,28 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -8684,6 +9899,15 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8744,8 +9968,13 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true,
-      "optional": true
+      "dev": true
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
+      "dev": true
     },
     "lodash.has": {
       "version": "4.5.2",
@@ -8846,8 +10075,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -9146,6 +10374,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true
     },
     "nanomatch": {
@@ -9462,6 +10696,21 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "optjs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
+    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -9752,6 +11001,12 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
+      "dev": true
+    },
     "prompts": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
@@ -9767,7 +11022,6 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
       "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -9788,8 +11042,7 @@
           "version": "10.17.13",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
           "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -12041,6 +13294,12 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
+    },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -12098,6 +13357,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
       "dev": true
     },
     "windows-release": {
@@ -12247,6 +13512,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
       "dev": true
     },
     "xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-simple",
-  "version": "6.0.1",
+  "version": "7.0.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint src __tests__ --ext=.ts",
     "lint:fix": "npm run lint -- --fix",
     "coverage": "codecov",
-    "publish:beta": "npm version prerelease && npm publish --tag beta",
+    "publish:beta": "npm run clean && npm run build && npm version prerelease && npm publish --tag beta",
     "release:prepare": "shipjs prepare",
     "release:trigger": "shipjs trigger"
   },

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "tsc --project .",
-    "build:test": "tsc --project test",
     "test": "jest",
+    "test:web": "jest __tests__/web",
+    "emulators:start": "firebase emulators:start --only firestore",
     "lint": "eslint src __tests__ --ext=.ts",
     "lint:fix": "npm run lint -- --fix",
     "coverage": "codecov",
@@ -23,6 +24,7 @@
     "utility-types": "3.10.0"
   },
   "devDependencies": {
+    "@firebase/testing": "0.16.14",
     "@types/jest": "25.1.3",
     "@typescript-eslint/eslint-plugin": "2.21.0",
     "@typescript-eslint/parser": "2.21.0",
@@ -33,6 +35,7 @@
     "eslint-plugin-node": "11.0.0",
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-standard": "4.0.1",
+    "firebase": "7.10.0",
     "firebase-admin": "8.9.2",
     "jest": "25.1.0",
     "jest-circus": "25.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-simple",
-  "version": "7.0.0-0",
+  "version": "7.0.0-1",
   "description": "A simple wrapper for Firestore",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-simple",
-  "version": "6.0.1",
+  "version": "7.0.0-0",
   "description": "A simple wrapper for Firestore",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/admin/admin.ts
+++ b/src/admin/admin.ts
@@ -1,5 +1,5 @@
 import { Firestore } from '@google-cloud/firestore'
-import { HasId, OmitId, Encodable, Decodable } from './types'
+import { HasId, OmitId, AdminEncodable, AdminDecodable } from './types'
 import { Context } from './context'
 import { AdminCollection } from './collection'
 import { AdminQuery } from './query'
@@ -13,8 +13,8 @@ export class FirestoreSimpleAdmin {
 
   collection<T extends HasId, S = OmitId<T>> ({ path, encode, decode }: {
     path: string,
-    encode?: Encodable<T, S>,
-    decode?: Decodable<T, S>,
+    encode?: AdminEncodable<T, S>,
+    decode?: AdminDecodable<T, S>,
   }): AdminCollection<T, S> {
     const factory = new CollectionFactory<T, S>({
       context: this.context,
@@ -25,8 +25,8 @@ export class FirestoreSimpleAdmin {
   }
 
   collectionFactory<T extends HasId, S = OmitId<T>> ({ encode, decode }: {
-    encode?: Encodable<T, S>,
-    decode?: Decodable<T, S>,
+    encode?: AdminEncodable<T, S>,
+    decode?: AdminDecodable<T, S>,
   }): CollectionFactory<T, S> {
     return new CollectionFactory<T, S>({
       context: this.context,
@@ -37,7 +37,7 @@ export class FirestoreSimpleAdmin {
 
   collectionGroup<T extends HasId, S = OmitId<T>> ({ collectionId, decode }: {
     collectionId: string,
-    decode?: Decodable<T, S>,
+    decode?: AdminDecodable<T, S>,
   }): AdminQuery<T, S> {
     const query = this.context.firestore.collectionGroup(collectionId)
     const converter = new AdminConverter({ decode })
@@ -55,13 +55,13 @@ export class FirestoreSimpleAdmin {
 
 class CollectionFactory<T extends HasId, S = OmitId<T>> {
   context: Context
-  encode?: Encodable<T, S>
-  decode?: Decodable<T, S>
+  encode?: AdminEncodable<T, S>
+  decode?: AdminDecodable<T, S>
 
   constructor ({ context, encode, decode }: {
     context: Context,
-    encode?: Encodable<T, S>,
-    decode?: Decodable<T, S>,
+    encode?: AdminEncodable<T, S>,
+    decode?: AdminDecodable<T, S>,
   }) {
     this.context = context
     this.encode = encode

--- a/src/admin/collection.ts
+++ b/src/admin/collection.ts
@@ -4,7 +4,7 @@ import {
   DocumentSnapshot,
   QuerySnapshot,
 } from '@google-cloud/firestore'
-import { HasId, OmitId, Encodable, Decodable, OptionalIdStorable, Storable, PartialStorable, QueryKey } from './types'
+import { HasId, OmitId, AdminEncodable, AdminDecodable, OptionalIdStorable, Storable, PartialStorable, QueryKey } from './types'
 import { Context } from './context'
 import { AdminConverter } from './converter'
 import { AdminQuery } from './query'
@@ -17,8 +17,8 @@ export class AdminCollection<T extends HasId, S = OmitId<T>> {
   constructor ({ context, path, encode, decode }: {
     context: Context,
     path: string,
-    encode?: Encodable<T, S>,
-    decode?: Decodable<T, S>,
+    encode?: AdminEncodable<T, S>,
+    decode?: AdminDecodable<T, S>,
   }) {
     this.context = context
     this.collectionRef = context.firestore.collection(path)

--- a/src/admin/converter.ts
+++ b/src/admin/converter.ts
@@ -1,14 +1,14 @@
 import { DocumentSnapshot } from '@google-cloud/firestore'
-import { HasId, OmitId, Encodable, Decodable, OptionalIdStorable, Storable } from './types'
+import { HasId, OmitId, AdminEncodable, AdminDecodable, OptionalIdStorable, Storable } from './types'
 import { Optional } from 'utility-types'
 
 export class AdminConverter<T extends HasId, S = OmitId<T>> {
-  private _encode?: Encodable<T, S>
-  private _decode?: Decodable<T, S>
+  private _encode?: AdminEncodable<T, S>
+  private _decode?: AdminDecodable<T, S>
 
   constructor ({ encode, decode }: {
-    encode?: Encodable<T, S>,
-    decode?: Decodable<T, S>,
+    encode?: AdminEncodable<T, S>,
+    decode?: AdminDecodable<T, S>,
   }) {
     this._encode = encode
     this._decode = decode

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -14,5 +14,5 @@ type HasSameKeyObject<T> = { [P in keyof T]: any }
 export type QueryKey<T> = { [K in keyof T]: K }[keyof T] | FirebaseFirestore.FieldPath
 // Convert 'id' property to optional type
 export type OmitId<T> = Omit<T, 'id'>
-export type Encodable<T extends HasId, S = FirebaseFirestore.DocumentData> = (obj: OptionalIdStorable<T>) => Storable<S>
-export type Decodable<T extends HasId, S = HasIdObject> = (doc: HasSameKeyObject<S> & HasId) => T
+export type AdminEncodable<T extends HasId, S = FirebaseFirestore.DocumentData> = (obj: OptionalIdStorable<T>) => Storable<S>
+export type AdminDecodable<T extends HasId, S = HasIdObject> = (doc: HasSameKeyObject<S> & HasId) => T

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
+// Ailias name for campatible before v6.0.0
 export { FirestoreSimpleAdmin as FirestoreSimple } from './admin/admin'
+
+// Admin SDK
 export { FirestoreSimpleAdmin } from './admin/admin'
 export type { AdminCollection } from './admin/collection'
 export type { Encodable, Decodable } from './admin/types'
+
+// Web SDK
+export { FirestoreSimpleWeb } from './web/web'
+// TODO: export WebCollection and Encodable, Decodable

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 // Ailias name for campatible before v6.0.0
 export { FirestoreSimpleAdmin as FirestoreSimple } from './admin/admin'
+export type { AdminEncodable as Encodable, AdminDecodable as Decodable } from './admin/types'
 
 // Admin SDK
 export { FirestoreSimpleAdmin } from './admin/admin'
 export type { AdminCollection } from './admin/collection'
-export type { Encodable, Decodable } from './admin/types'
+export type { AdminEncodable, AdminDecodable } from './admin/types'
 
 // Web SDK
 export { FirestoreSimpleWeb } from './web/web'
-// TODO: export WebCollection and Encodable, Decodable
+export type { WebCollection } from './web/collection'
+export type { WebEncodable, WebDecodable } from './web/types'

--- a/src/web/collection.ts
+++ b/src/web/collection.ts
@@ -1,0 +1,44 @@
+import type { firestore } from 'firebase'
+import { HasId, OmitId, Encodable, Decodable } from './types'
+import { Context } from './context'
+import { WebConverter } from './converter'
+
+export class WebCollection<T extends HasId, S = OmitId<T>> {
+  context: Context
+  collectionRef: firestore.CollectionReference
+  private converter: WebConverter<T, S>
+
+  constructor ({ context, path, encode, decode }: {
+    context: Context,
+    path: string,
+    encode?: Encodable<T, S>,
+    decode?: Decodable<T, S>,
+  }) {
+    this.context = context
+    this.collectionRef = context.firestore.collection(path)
+    this.converter = new WebConverter({ encode, decode })
+  }
+
+  toObject (documentSnapshot: firestore.DocumentSnapshot): T {
+    return this.converter.decode(documentSnapshot)
+  }
+
+  docRef (id?: string): firestore.DocumentReference {
+    if (id) return this.collectionRef.doc(id)
+    return this.collectionRef.doc()
+  }
+
+  async fetch (id: string): Promise <T | undefined> {
+    const docRef = this.docRef(id)
+    const snapshot = await docRef.get()
+    if (!snapshot.exists) return undefined
+
+    return this.toObject(snapshot)
+  }
+
+  async fetchAll (): Promise<T[]> {
+    const snapshot = await this.collectionRef.get()
+
+    return snapshot.docs.map((snapshot) => this.toObject(snapshot))
+  }
+}

--- a/src/web/collection.ts
+++ b/src/web/collection.ts
@@ -1,5 +1,5 @@
 import type { firestore } from 'firebase'
-import { HasId, OmitId, Encodable, Decodable, OptionalIdStorable, Storable, PartialStorable, QueryKey } from './types'
+import { HasId, OmitId, WebEncodable, WebDecodable, OptionalIdStorable, Storable, PartialStorable, QueryKey } from './types'
 import { Context } from './context'
 import { WebConverter } from './converter'
 import { WebQuery } from './query'
@@ -12,8 +12,8 @@ export class WebCollection<T extends HasId, S = OmitId<T>> {
   constructor ({ context, path, encode, decode }: {
     context: Context,
     path: string,
-    encode?: Encodable<T, S>,
-    decode?: Decodable<T, S>,
+    encode?: WebEncodable<T, S>,
+    decode?: WebDecodable<T, S>,
   }) {
     this.context = context
     this.collectionRef = context.firestore.collection(path)

--- a/src/web/context.ts
+++ b/src/web/context.ts
@@ -1,0 +1,8 @@
+import type { firestore } from 'firebase'
+
+export class Context {
+  firestore: firestore.Firestore
+  constructor (firestore: firestore.Firestore) {
+    this.firestore = firestore
+  }
+}

--- a/src/web/context.ts
+++ b/src/web/context.ts
@@ -2,7 +2,38 @@ import type { firestore } from 'firebase'
 
 export class Context {
   firestore: firestore.Firestore
+  private _tx?: firestore.Transaction = undefined
+  private _batch?: firestore.WriteBatch = undefined
   constructor (firestore: firestore.Firestore) {
     this.firestore = firestore
+  }
+
+  get tx (): firestore.Transaction | undefined {
+    return this._tx
+  }
+
+  get batch (): firestore.WriteBatch | undefined {
+    return this._batch
+  }
+
+  async runTransaction (updateFunction: (tx: firestore.Transaction) => Promise<void>): Promise<void> {
+    if (this._tx || this._batch) throw new Error('Disallow nesting transaction or batch')
+
+    await this.firestore.runTransaction(async (tx) => {
+      this._tx = tx
+      await updateFunction(tx)
+    })
+    this._tx = undefined
+  }
+
+  async runBatch (updateFunction: (batch: firestore.WriteBatch) => Promise<void>): Promise<void> {
+    if (this._tx || this._batch) throw new Error('Disallow nesting transaction or batch')
+
+    this._batch = this.firestore.batch()
+
+    await updateFunction(this._batch)
+    await this._batch.commit()
+
+    this._batch = undefined
   }
 }

--- a/src/web/converter.ts
+++ b/src/web/converter.ts
@@ -1,0 +1,31 @@
+import type { firestore } from 'firebase'
+import { HasId, OmitId, Encodable, Decodable, OptionalIdStorable, Storable } from './types'
+import { Optional } from 'utility-types'
+
+export class WebConverter<T extends HasId, S = OmitId<T>> {
+  private _encode?: Encodable<T, S>
+  private _decode?: Decodable<T, S>
+
+  constructor ({ encode, decode }: {
+    encode?: Encodable<T, S>,
+    decode?: Decodable<T, S>,
+  }) {
+    this._encode = encode
+    this._decode = decode
+  }
+
+  decode (documentSnapshot: firestore.DocumentSnapshot): T {
+    const obj = { id: documentSnapshot.id, ...documentSnapshot.data() }
+    if (this._decode) return this._decode(obj as S & HasId)
+
+    return obj as T
+  }
+
+  encode (obj: OptionalIdStorable<T>): Optional<Storable<T>, 'id'> | Storable<S> {
+    if (this._encode) return this._encode(obj)
+
+    const doc = { ...obj }
+    if ('id' in doc) delete doc.id
+    return doc
+  }
+}

--- a/src/web/converter.ts
+++ b/src/web/converter.ts
@@ -1,14 +1,14 @@
 import type { firestore } from 'firebase'
-import { HasId, OmitId, Encodable, Decodable, OptionalIdStorable, Storable } from './types'
+import { HasId, OmitId, WebEncodable, WebDecodable, OptionalIdStorable, Storable } from './types'
 import { Optional } from 'utility-types'
 
 export class WebConverter<T extends HasId, S = OmitId<T>> {
-  private _encode?: Encodable<T, S>
-  private _decode?: Decodable<T, S>
+  private _encode?: WebEncodable<T, S>
+  private _decode?: WebDecodable<T, S>
 
   constructor ({ encode, decode }: {
-    encode?: Encodable<T, S>,
-    decode?: Decodable<T, S>,
+    encode?: WebEncodable<T, S>,
+    decode?: WebDecodable<T, S>,
   }) {
     this._encode = encode
     this._decode = decode

--- a/src/web/query.ts
+++ b/src/web/query.ts
@@ -1,0 +1,107 @@
+import { firestore } from 'firebase'
+import { HasId, QueryKey } from './types'
+import { WebConverter } from './converter'
+import { Context } from './context'
+
+export class WebQuery<T extends HasId, S> {
+  constructor (public converter: WebConverter<T, S>, public context: Context, public query: firestore.Query) { }
+
+  where (fieldPath: QueryKey<S>, opStr: FirebaseFirestore.WhereFilterOp, value: any): this {
+    this.query = this.query.where(fieldPath as string | FirebaseFirestore.FieldPath, opStr, value)
+    return this
+  }
+
+  orderBy (fieldPath: QueryKey<S>, directionStr?: FirebaseFirestore.OrderByDirection): this {
+    this.query = this.query.orderBy(fieldPath as string | FirebaseFirestore.FieldPath, directionStr)
+    return this
+  }
+
+  limit (limit: number): this {
+    this.query = this.query.limit(limit)
+    return this
+  }
+
+  startAt (snapshot: firestore.DocumentSnapshot): WebQuery<T, S>
+  startAt (...fieldValues: any[]): WebQuery<T, S>
+  startAt (
+    snapshotOrValue: firestore.DocumentSnapshot | unknown,
+    ...fieldValues: unknown[]
+  ): this {
+    if (!this.query) throw new Error('no query statement before startAt()')
+
+    if (snapshotOrValue instanceof firestore.DocumentSnapshot) {
+      this.query = this.query.startAt(snapshotOrValue)
+    } else {
+      this.query = this.query.startAt(snapshotOrValue, ...fieldValues)
+    }
+    return this
+  }
+
+  startAfter (snapshot: firestore.DocumentSnapshot): WebQuery<T, S>
+  startAfter (...fieldValues: any[]): WebQuery<T, S>
+  startAfter (
+    snapshotOrValue: firestore.DocumentSnapshot | unknown,
+    ...fieldValues: unknown[]
+  ): this {
+    if (!this.query) throw new Error('no query statement before startAfter()')
+
+    if (snapshotOrValue instanceof firestore.DocumentSnapshot) {
+      this.query = this.query.startAfter(snapshotOrValue)
+    } else {
+      this.query = this.query.startAfter(snapshotOrValue, ...fieldValues)
+    }
+    return this
+  }
+
+  endAt (snapshot: firestore.DocumentSnapshot): WebQuery<T, S>
+  endAt (...fieldValues: any[]): WebQuery<T, S>
+  endAt (
+    snapshotOrValue: firestore.DocumentSnapshot | unknown,
+    ...fieldValues: unknown[]
+  ): this {
+    if (!this.query) throw new Error('no query statement before endAt()')
+
+    if (snapshotOrValue instanceof firestore.DocumentSnapshot) {
+      this.query = this.query.endAt(snapshotOrValue)
+    } else {
+      this.query = this.query.endAt(snapshotOrValue, ...fieldValues)
+    }
+    return this
+  }
+
+  endBefore (snapshot: firestore.DocumentSnapshot): WebQuery<T, S>
+  endBefore (...fieldValues: any[]): WebQuery<T, S>
+  endBefore (
+    snapshotOrValue: firestore.DocumentSnapshot | unknown,
+    ...fieldValues: unknown[]
+  ): this {
+    if (!this.query) throw new Error('no query statement before endBefore()')
+
+    if (snapshotOrValue instanceof firestore.DocumentSnapshot) {
+      this.query = this.query.endBefore(snapshotOrValue)
+    } else {
+      this.query = this.query.endBefore(snapshotOrValue, ...fieldValues)
+    }
+    return this
+  }
+
+  async fetch (): Promise<T[]> {
+    if (!this.query) throw new Error('no query statement before fetch()')
+
+    const snapshot = await this.query.get()
+    return snapshot.docs.map((documentSnapshot) => {
+      return this.converter.decode(documentSnapshot)
+    })
+  }
+
+  onSnapshot (callback: (
+    querySnapshot: firestore.QuerySnapshot,
+    toObject: (documentSnapshot: firestore.DocumentSnapshot) => T
+    ) => void
+  ): () => void {
+    if (!this.query) throw new Error('no query statement before onSnapshot()')
+    return this.query.onSnapshot((_querySnapshot) => {
+      callback(_querySnapshot, this.converter.decode.bind(this.converter))
+    })
+  }
+}

--- a/src/web/query.ts
+++ b/src/web/query.ts
@@ -87,6 +87,7 @@ export class WebQuery<T extends HasId, S> {
 
   async fetch (): Promise<T[]> {
     if (!this.query) throw new Error('no query statement before fetch()')
+    if (this.context.tx) throw new Error('Web SDK transaction.get() does not support QuerySnapshot')
 
     const snapshot = await this.query.get()
     return snapshot.docs.map((documentSnapshot) => {

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -14,5 +14,5 @@ type HasSameKeyObject<T> = { [P in keyof T]: any }
 export type QueryKey<T> = { [K in keyof T]: K }[keyof T] | firestore.FieldPath
 // Convert 'id' property to optional type
 export type OmitId<T> = Omit<T, 'id'>
-export type Encodable<T extends HasId, S = firestore.DocumentData> = (obj: OptionalIdStorable<T>) => Storable<S>
-export type Decodable<T extends HasId, S = HasIdObject> = (doc: HasSameKeyObject<S> & HasId) => T
+export type WebEncodable<T extends HasId, S = firestore.DocumentData> = (obj: OptionalIdStorable<T>) => Storable<S>
+export type WebDecodable<T extends HasId, S = HasIdObject> = (doc: HasSameKeyObject<S> & HasId) => T

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -1,0 +1,18 @@
+import { FieldValue } from '@google-cloud/firestore'
+import { Omit, Optional } from 'utility-types'
+
+export type HasId = { id: string }
+export type HasIdObject = { id: string, [key: string]: any }
+// Accpet original type and Firestore.FieldValue without 'id' property
+export type Storable<T> = { [P in keyof T]: P extends 'id' ? T[P] : T[P] | FieldValue }
+// Storable but only 'id' is optional
+export type OptionalIdStorable<T extends HasId> = Optional<Storable<T>, 'id'>
+// Storable but all keys exclude 'id' are optional
+export type PartialStorable<T extends HasId> = Partial<Storable<T>> & HasId
+
+type HasSameKeyObject<T> = { [P in keyof T]: any }
+export type QueryKey<T> = { [K in keyof T]: K }[keyof T] | FirebaseFirestore.FieldPath
+// Convert 'id' property to optional type
+export type OmitId<T> = Omit<T, 'id'>
+export type Encodable<T extends HasId, S = FirebaseFirestore.DocumentData> = (obj: OptionalIdStorable<T>) => Storable<S>
+export type Decodable<T extends HasId, S = HasIdObject> = (doc: HasSameKeyObject<S> & HasId) => T

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -1,18 +1,18 @@
-import { FieldValue } from '@google-cloud/firestore'
+import type { firestore } from 'firebase'
 import { Omit, Optional } from 'utility-types'
 
 export type HasId = { id: string }
 export type HasIdObject = { id: string, [key: string]: any }
 // Accpet original type and Firestore.FieldValue without 'id' property
-export type Storable<T> = { [P in keyof T]: P extends 'id' ? T[P] : T[P] | FieldValue }
+export type Storable<T> = { [P in keyof T]: P extends 'id' ? T[P] : T[P] | firestore.FieldValue }
 // Storable but only 'id' is optional
 export type OptionalIdStorable<T extends HasId> = Optional<Storable<T>, 'id'>
 // Storable but all keys exclude 'id' are optional
 export type PartialStorable<T extends HasId> = Partial<Storable<T>> & HasId
 
 type HasSameKeyObject<T> = { [P in keyof T]: any }
-export type QueryKey<T> = { [K in keyof T]: K }[keyof T] | FirebaseFirestore.FieldPath
+export type QueryKey<T> = { [K in keyof T]: K }[keyof T] | firestore.FieldPath
 // Convert 'id' property to optional type
 export type OmitId<T> = Omit<T, 'id'>
-export type Encodable<T extends HasId, S = FirebaseFirestore.DocumentData> = (obj: OptionalIdStorable<T>) => Storable<S>
+export type Encodable<T extends HasId, S = firestore.DocumentData> = (obj: OptionalIdStorable<T>) => Storable<S>
 export type Decodable<T extends HasId, S = HasIdObject> = (doc: HasSameKeyObject<S> & HasId) => T

--- a/src/web/web.ts
+++ b/src/web/web.ts
@@ -3,6 +3,8 @@ import { HasId, Encodable, Decodable } from './types'
 import { OmitId } from '../admin/types'
 import { Context } from './context'
 import { WebCollection } from './collection'
+import { WebQuery } from './query'
+import { WebConverter } from './converter'
 
 export class FirestoreSimpleWeb {
   context: Context
@@ -21,6 +23,15 @@ export class FirestoreSimpleWeb {
       decode,
     })
     return factory.create(path)
+  }
+
+  collectionGroup<T extends HasId, S = OmitId<T>> ({ collectionId, decode }: {
+    collectionId: string,
+    decode?: Decodable<T, S>,
+  }): WebQuery<T, S> {
+    const query = this.context.firestore.collectionGroup(collectionId)
+    const converter = new WebConverter({ decode })
+    return new WebQuery<T, S>(converter, this.context, query)
   }
 
   async runTransaction (updateFunction: (tx: firestore.Transaction) => Promise<void>): Promise<void> {

--- a/src/web/web.ts
+++ b/src/web/web.ts
@@ -1,0 +1,50 @@
+import * as firebase from 'firebase/app'
+import 'firebase/firestore'
+import { HasId, Encodable, Decodable } from './types'
+import { OmitId } from '../admin/types'
+import { Context } from './context'
+import { WebCollection } from './collection'
+
+export class FirestoreSimpleWeb {
+  context: Context
+  constructor (firestore: firebase.firestore.Firestore) {
+    this.context = new Context(firestore)
+  }
+
+  collection<T extends HasId, S = OmitId<T>> ({ path, encode, decode }: {
+    path: string,
+    encode?: Encodable<T, S>,
+    decode?: Decodable<T, S>,
+  }): WebCollection<T, S> {
+    const factory = new CollectionFactory<T, S>({
+      context: this.context,
+      encode,
+      decode,
+    })
+    return factory.create(path)
+  }
+}
+class CollectionFactory<T extends HasId, S = OmitId<T>> {
+  context: Context
+  encode?: Encodable<T, S>
+  decode?: Decodable<T, S>
+
+  constructor ({ context, encode, decode }: {
+    context: Context,
+    encode?: Encodable<T, S>,
+    decode?: Decodable<T, S>,
+  }) {
+    this.context = context
+    this.encode = encode
+    this.decode = decode
+  }
+
+  create (path: string): WebCollection<T, S> {
+    return new WebCollection<T, S>({
+      context: this.context,
+      path,
+      encode: this.encode,
+      decode: this.decode,
+    })
+  }
+}

--- a/src/web/web.ts
+++ b/src/web/web.ts
@@ -1,5 +1,4 @@
-import * as firebase from 'firebase/app'
-import 'firebase/firestore'
+import type { firestore } from 'firebase'
 import { HasId, Encodable, Decodable } from './types'
 import { OmitId } from '../admin/types'
 import { Context } from './context'
@@ -7,7 +6,7 @@ import { WebCollection } from './collection'
 
 export class FirestoreSimpleWeb {
   context: Context
-  constructor (firestore: firebase.firestore.Firestore) {
+  constructor (firestore: firestore.Firestore) {
     this.context = new Context(firestore)
   }
 
@@ -23,7 +22,16 @@ export class FirestoreSimpleWeb {
     })
     return factory.create(path)
   }
+
+  async runTransaction (updateFunction: (tx: firestore.Transaction) => Promise<void>): Promise<void> {
+    return this.context.runTransaction(updateFunction)
+  }
+
+  async runBatch (updateFunction: (batch: firestore.WriteBatch) => Promise<void>): Promise<void> {
+    return this.context.runBatch(updateFunction)
+  }
 }
+
 class CollectionFactory<T extends HasId, S = OmitId<T>> {
   context: Context
   encode?: Encodable<T, S>

--- a/src/web/web.ts
+++ b/src/web/web.ts
@@ -1,5 +1,5 @@
 import type { firestore } from 'firebase'
-import { HasId, Encodable, Decodable } from './types'
+import { HasId, WebEncodable, WebDecodable } from './types'
 import { OmitId } from '../admin/types'
 import { Context } from './context'
 import { WebCollection } from './collection'
@@ -14,8 +14,8 @@ export class FirestoreSimpleWeb {
 
   collection<T extends HasId, S = OmitId<T>> ({ path, encode, decode }: {
     path: string,
-    encode?: Encodable<T, S>,
-    decode?: Decodable<T, S>,
+    encode?: WebEncodable<T, S>,
+    decode?: WebDecodable<T, S>,
   }): WebCollection<T, S> {
     const factory = new CollectionFactory<T, S>({
       context: this.context,
@@ -26,8 +26,8 @@ export class FirestoreSimpleWeb {
   }
 
   collectionFactory<T extends HasId, S = OmitId<T>> ({ encode, decode }: {
-    encode?: Encodable<T, S>,
-    decode?: Decodable<T, S>,
+    encode?: WebEncodable<T, S>,
+    decode?: WebDecodable<T, S>,
   }): CollectionFactory<T, S> {
     return new CollectionFactory<T, S>({
       context: this.context,
@@ -38,7 +38,7 @@ export class FirestoreSimpleWeb {
 
   collectionGroup<T extends HasId, S = OmitId<T>> ({ collectionId, decode }: {
     collectionId: string,
-    decode?: Decodable<T, S>,
+    decode?: WebDecodable<T, S>,
   }): WebQuery<T, S> {
     const query = this.context.firestore.collectionGroup(collectionId)
     const converter = new WebConverter({ decode })
@@ -56,13 +56,13 @@ export class FirestoreSimpleWeb {
 
 class CollectionFactory<T extends HasId, S = OmitId<T>> {
   context: Context
-  encode?: Encodable<T, S>
-  decode?: Decodable<T, S>
+  encode?: WebEncodable<T, S>
+  decode?: WebDecodable<T, S>
 
   constructor ({ context, encode, decode }: {
     context: Context,
-    encode?: Encodable<T, S>,
-    decode?: Decodable<T, S>,
+    encode?: WebEncodable<T, S>,
+    decode?: WebDecodable<T, S>,
   }) {
     this.context = context
     this.encode = encode

--- a/src/web/web.ts
+++ b/src/web/web.ts
@@ -25,6 +25,17 @@ export class FirestoreSimpleWeb {
     return factory.create(path)
   }
 
+  collectionFactory<T extends HasId, S = OmitId<T>> ({ encode, decode }: {
+    encode?: Encodable<T, S>,
+    decode?: Decodable<T, S>,
+  }): CollectionFactory<T, S> {
+    return new CollectionFactory<T, S>({
+      context: this.context,
+      encode,
+      decode,
+    })
+  }
+
   collectionGroup<T extends HasId, S = OmitId<T>> ({ collectionId, decode }: {
     collectionId: string,
     decode?: Decodable<T, S>,


### PR DESCRIPTION
**currently still developing**

Try supporting Web SDK and export classes for Admin SDK and Web SDK.
Almost all Web SDK features are supported. These are confirmed by new tests that using Firestore emulator.

But current approach that each classes in one package is requires both `firebase` and `firebase-admin` packages for resolve types when compile TypeScript.
It is not good when use only each Firestore SDK. So I merge this pull request but still find more better solution for next version v7.
