### PR TITLE
refactor: improve internal types

### DIFF
--- a/packages/admin/__tests__/util.ts
+++ b/packages/admin/__tests__/util.ts
@@ -1,4 +1,4 @@
-import { Firestore } from '@google-cloud/firestore'
+import { Firestore } from '../src/types'
 import crypto from 'crypto'
 import admin, { ServiceAccount } from 'firebase-admin'
 import serviceAccount from '../firebase_secret.json'

--- a/packages/admin/src/admin.ts
+++ b/packages/admin/src/admin.ts
@@ -1,5 +1,4 @@
-import { Firestore } from '@google-cloud/firestore'
-import { HasId, OmitId, AdminEncodable, AdminDecodable } from './types'
+import { HasId, OmitId, AdminEncodable, AdminDecodable, Firestore } from './types'
 import { Context } from './context'
 import { AdminCollection } from './collection'
 import { AdminQuery } from './query'

--- a/packages/admin/src/collection.ts
+++ b/packages/admin/src/collection.ts
@@ -1,10 +1,4 @@
-import {
-  CollectionReference,
-  DocumentReference,
-  DocumentSnapshot,
-  QuerySnapshot,
-} from '@google-cloud/firestore'
-import { HasId, OmitId, AdminEncodable, AdminDecodable, OptionalIdStorable, Storable, PartialStorable, QueryKey } from './types'
+import { HasId, OmitId, AdminEncodable, AdminDecodable, OptionalIdStorable, Storable, PartialStorable, QueryKey, CollectionReference, DocumentSnapshot, DocumentReference, QuerySnapshot } from './types'
 import { Context } from './context'
 import { AdminConverter } from './converter'
 import { AdminQuery } from './query'

--- a/packages/admin/src/context.ts
+++ b/packages/admin/src/context.ts
@@ -1,22 +1,22 @@
-import { Firestore } from '@google-cloud/firestore'
+import { Firestore, Transaction, WriteBatch, WriteResult } from './types'
 
 export class Context {
   firestore: Firestore
-  private _tx?: FirebaseFirestore.Transaction = undefined
-  private _batch?: FirebaseFirestore.WriteBatch = undefined
+  private _tx?: Transaction = undefined
+  private _batch?: WriteBatch = undefined
   constructor (firestore: Firestore) {
     this.firestore = firestore
   }
 
-  get tx (): FirebaseFirestore.Transaction | undefined {
+  get tx (): Transaction | undefined {
     return this._tx
   }
 
-  get batch (): FirebaseFirestore.WriteBatch | undefined {
+  get batch (): WriteBatch | undefined {
     return this._batch
   }
 
-  async runTransaction (updateFunction: (tx: FirebaseFirestore.Transaction) => Promise<void>): Promise<void> {
+  async runTransaction (updateFunction: (tx: Transaction) => Promise<void>): Promise<void> {
     if (this._tx || this._batch) throw new Error('Disallow nesting transaction or batch')
 
     await this.firestore.runTransaction(async (tx) => {
@@ -26,7 +26,7 @@ export class Context {
     this._tx = undefined
   }
 
-  async runBatch (updateFunction: (batch: FirebaseFirestore.WriteBatch) => Promise<void>): Promise<FirebaseFirestore.WriteResult[]> {
+  async runBatch (updateFunction: (batch: WriteBatch) => Promise<void>): Promise<WriteResult[]> {
     if (this._tx || this._batch) throw new Error('Disallow nesting transaction or batch')
 
     this._batch = this.firestore.batch()

--- a/packages/admin/src/converter.ts
+++ b/packages/admin/src/converter.ts
@@ -1,5 +1,4 @@
-import { DocumentSnapshot } from '@google-cloud/firestore'
-import { HasId, OmitId, AdminEncodable, AdminDecodable, OptionalIdStorable, Storable } from './types'
+import { HasId, OmitId, AdminEncodable, AdminDecodable, OptionalIdStorable, Storable, DocumentSnapshot } from './types'
 import { Optional } from 'utility-types'
 
 export class AdminConverter<T extends HasId, S = OmitId<T>> {

--- a/packages/admin/src/query.ts
+++ b/packages/admin/src/query.ts
@@ -1,18 +1,17 @@
-import { DocumentSnapshot, Query, QuerySnapshot } from '@google-cloud/firestore'
-import { HasId, QueryKey } from './types'
+import { HasId, QueryKey, Query, WhereFilterOp, FieldPath, OrderByDirection, DocumentSnapshot, QuerySnapshot } from './types'
 import { AdminConverter } from './converter'
 import { Context } from './context'
 
 export class AdminQuery<T extends HasId, S> {
   constructor (public converter: AdminConverter<T, S>, public context: Context, public query: Query) { }
 
-  where (fieldPath: QueryKey<S>, opStr: FirebaseFirestore.WhereFilterOp, value: any): this {
-    this.query = this.query.where(fieldPath as string | FirebaseFirestore.FieldPath, opStr, value)
+  where (fieldPath: QueryKey<S>, opStr: WhereFilterOp, value: any): this {
+    this.query = this.query.where(fieldPath as string | FieldPath, opStr, value)
     return this
   }
 
-  orderBy (fieldPath: QueryKey<S>, directionStr?: FirebaseFirestore.OrderByDirection): this {
-    this.query = this.query.orderBy(fieldPath as string | FirebaseFirestore.FieldPath, directionStr)
+  orderBy (fieldPath: QueryKey<S>, directionStr?: OrderByDirection): this {
+    this.query = this.query.orderBy(fieldPath as string | FieldPath, directionStr)
     return this
   }
 

--- a/packages/admin/src/types.ts
+++ b/packages/admin/src/types.ts
@@ -1,18 +1,32 @@
-import { FieldValue } from '@google-cloud/firestore'
+import firestore from '@google-cloud/firestore'
 import { Omit, Optional } from 'utility-types'
 
 export type HasId = { id: string }
 export type HasIdObject = { id: string, [key: string]: any }
 // Accpet original type and Firestore.FieldValue without 'id' property
-export type Storable<T> = { [P in keyof T]: P extends 'id' ? T[P] : T[P] | FieldValue }
+export type Storable<T> = { [P in keyof T]: P extends 'id' ? T[P] : T[P] | firestore.FieldValue }
 // Storable but only 'id' is optional
 export type OptionalIdStorable<T extends HasId> = Optional<Storable<T>, 'id'>
 // Storable but all keys exclude 'id' are optional
 export type PartialStorable<T extends HasId> = Partial<Storable<T>> & HasId
 
 type HasSameKeyObject<T> = { [P in keyof T]: any }
-export type QueryKey<T> = { [K in keyof T]: K }[keyof T] | FirebaseFirestore.FieldPath
+export type QueryKey<T> = { [K in keyof T]: K }[keyof T] | firestore.FieldPath
 // Convert 'id' property to optional type
 export type OmitId<T> = Omit<T, 'id'>
-export type AdminEncodable<T extends HasId, S = FirebaseFirestore.DocumentData> = (obj: OptionalIdStorable<T>) => Storable<S>
+export type AdminEncodable<T extends HasId, S = firestore.DocumentData> = (obj: OptionalIdStorable<T>) => Storable<S>
 export type AdminDecodable<T extends HasId, S = HasIdObject> = (doc: HasSameKeyObject<S> & HasId) => T
+
+// Export Firestore types
+export import Firestore = firestore.Firestore
+export import DocumentReference = firestore.DocumentReference
+export import CollectionReference = firestore.CollectionReference
+export import DocumentSnapshot = firestore.DocumentSnapshot
+export import QuerySnapshot = firestore.QuerySnapshot
+export import Transaction = firestore.Transaction
+export import WriteBatch = firestore.WriteBatch
+export import WriteResult = firestore.WriteResult
+export import Query = firestore.Query
+export import WhereFilterOp = firestore.WhereFilterOp
+export import FieldPath = firestore.FieldPath
+export import OrderByDirection = firestore.OrderByDirection

--- a/packages/web/src/collection.ts
+++ b/packages/web/src/collection.ts
@@ -1,12 +1,11 @@
-import { firestore } from 'firebase/app'
-import { HasId, OmitId, WebEncodable, WebDecodable, OptionalIdStorable, Storable, PartialStorable, QueryKey } from './types'
+import { HasId, OmitId, WebEncodable, WebDecodable, OptionalIdStorable, Storable, PartialStorable, QueryKey, DocumentSnapshot, WhereFilterOp, FieldPath, OrderByDirection, QuerySnapshot, CollectionReference, DocumentReference } from './types'
 import { Context } from './context'
 import { WebConverter } from './converter'
 import { WebQuery } from './query'
 
 export class WebCollection<T extends HasId, S = OmitId<T>> {
   context: Context
-  collectionRef: firestore.CollectionReference
+  collectionRef: CollectionReference
   private converter: WebConverter<T, S>
 
   constructor ({ context, path, encode, decode }: {
@@ -20,11 +19,11 @@ export class WebCollection<T extends HasId, S = OmitId<T>> {
     this.converter = new WebConverter({ encode, decode })
   }
 
-  toObject (documentSnapshot: firestore.DocumentSnapshot): T {
+  toObject (documentSnapshot: DocumentSnapshot): T {
     return this.converter.decode(documentSnapshot)
   }
 
-  docRef (id?: string): firestore.DocumentReference {
+  docRef (id?: string): DocumentReference {
     if (id) return this.collectionRef.doc(id)
     return this.collectionRef.doc()
   }
@@ -47,7 +46,7 @@ export class WebCollection<T extends HasId, S = OmitId<T>> {
   }
 
   async add (obj: OptionalIdStorable<T>): Promise<string> {
-    let docRef: firestore.DocumentReference
+    let docRef: DocumentReference
     const doc = this.converter.encode(obj)
 
     if (this.context.tx) {
@@ -132,13 +131,13 @@ export class WebCollection<T extends HasId, S = OmitId<T>> {
     })
   }
 
-  where (fieldPath: QueryKey<S>, opStr: firestore.WhereFilterOp, value: any): WebQuery<T, S> {
-    const query = this.collectionRef.where(fieldPath as string | firestore.FieldPath, opStr, value)
+  where (fieldPath: QueryKey<S>, opStr: WhereFilterOp, value: any): WebQuery<T, S> {
+    const query = this.collectionRef.where(fieldPath as string | FieldPath, opStr, value)
     return new WebQuery<T, S>(this.converter, this.context, query)
   }
 
-  orderBy (fieldPath: QueryKey<S>, directionStr?: firestore.OrderByDirection): WebQuery<T, S> {
-    const query = this.collectionRef.orderBy(fieldPath as string | firestore.FieldPath, directionStr)
+  orderBy (fieldPath: QueryKey<S>, directionStr?: OrderByDirection): WebQuery<T, S> {
+    const query = this.collectionRef.orderBy(fieldPath as string | FieldPath, directionStr)
     return new WebQuery<T, S>(this.converter, this.context, query)
   }
 
@@ -148,8 +147,8 @@ export class WebCollection<T extends HasId, S = OmitId<T>> {
   }
 
   onSnapshot (callback: (
-    querySnapshot: firestore.QuerySnapshot,
-    toObject: (documentSnapshot: firestore.DocumentSnapshot) => T
+    querySnapshot: QuerySnapshot,
+    toObject: (documentSnapshot: DocumentSnapshot) => T
     ) => void
   ): () => void {
     return this.collectionRef.onSnapshot((_querySnapshot) => {

--- a/packages/web/src/context.ts
+++ b/packages/web/src/context.ts
@@ -1,22 +1,22 @@
-import { firestore } from 'firebase/app'
+import { Firestore, Transaction, WriteBatch } from './types'
 
 export class Context {
-  firestore: firestore.Firestore
-  private _tx?: firestore.Transaction = undefined
-  private _batch?: firestore.WriteBatch = undefined
-  constructor (firestore: firebase.firestore.Firestore) {
+  firestore: Firestore
+  private _tx?: Transaction = undefined
+  private _batch?: WriteBatch = undefined
+  constructor (firestore: Firestore) {
     this.firestore = firestore
   }
 
-  get tx (): firestore.Transaction | undefined {
+  get tx (): Transaction | undefined {
     return this._tx
   }
 
-  get batch (): firestore.WriteBatch | undefined {
+  get batch (): WriteBatch | undefined {
     return this._batch
   }
 
-  async runTransaction (updateFunction: (tx: firestore.Transaction) => Promise<void>): Promise<void> {
+  async runTransaction (updateFunction: (tx: Transaction) => Promise<void>): Promise<void> {
     if (this._tx || this._batch) throw new Error('Disallow nesting transaction or batch')
 
     await this.firestore.runTransaction(async (tx) => {
@@ -26,7 +26,7 @@ export class Context {
     this._tx = undefined
   }
 
-  async runBatch (updateFunction: (batch: firestore.WriteBatch) => Promise<void>): Promise<void> {
+  async runBatch (updateFunction: (batch: WriteBatch) => Promise<void>): Promise<void> {
     if (this._tx || this._batch) throw new Error('Disallow nesting transaction or batch')
 
     this._batch = this.firestore.batch()

--- a/packages/web/src/converter.ts
+++ b/packages/web/src/converter.ts
@@ -1,7 +1,4 @@
-import { firestore } from 'firebase/app'
-
-import { HasId, OmitId, WebEncodable, WebDecodable, OptionalIdStorable, Storable } from './types'
-import { Optional } from 'utility-types'
+import { HasId, OmitId, WebEncodable, WebDecodable, OptionalIdStorable, Storable, DocumentSnapshot } from './types'
 
 export class WebConverter<T extends HasId, S = OmitId<T>> {
   private _encode?: WebEncodable<T, S>
@@ -15,14 +12,14 @@ export class WebConverter<T extends HasId, S = OmitId<T>> {
     this._decode = decode
   }
 
-  decode (documentSnapshot: firestore.DocumentSnapshot): T {
+  decode (documentSnapshot: DocumentSnapshot): T {
     const obj = { id: documentSnapshot.id, ...documentSnapshot.data() }
     if (this._decode) return this._decode(obj as S & HasId)
 
     return obj as T
   }
 
-  encode (obj: OptionalIdStorable<T>): Optional<Storable<T>, 'id'> | Storable<S> {
+  encode (obj: OptionalIdStorable<T>): OptionalIdStorable<T> | Storable<S> {
     if (this._encode) return this._encode(obj)
 
     const doc = { ...obj }

--- a/packages/web/src/query.ts
+++ b/packages/web/src/query.ts
@@ -1,19 +1,19 @@
 import { firestore } from 'firebase/app'
 import '@firebase/firestore' // for instanceof firestore.DocumentSnapshot
-import { HasId, QueryKey } from './types'
+import { HasId, QueryKey, DocumentSnapshot, QuerySnapshot, WhereFilterOp, FieldPath, OrderByDirection, Query } from './types'
 import { WebConverter } from './converter'
 import { Context } from './context'
 
 export class WebQuery<T extends HasId, S> {
-  constructor (public converter: WebConverter<T, S>, public context: Context, public query: firestore.Query) { }
+  constructor (public converter: WebConverter<T, S>, public context: Context, public query: Query) { }
 
-  where (fieldPath: QueryKey<S>, opStr: firestore.WhereFilterOp, value: any): this {
-    this.query = this.query.where(fieldPath as string | firestore.FieldPath, opStr, value)
+  where (fieldPath: QueryKey<S>, opStr: WhereFilterOp, value: any): this {
+    this.query = this.query.where(fieldPath as string | FieldPath, opStr, value)
     return this
   }
 
-  orderBy (fieldPath: QueryKey<S>, directionStr?: firestore.OrderByDirection): this {
-    this.query = this.query.orderBy(fieldPath as string | firestore.FieldPath, directionStr)
+  orderBy (fieldPath: QueryKey<S>, directionStr?: OrderByDirection): this {
+    this.query = this.query.orderBy(fieldPath as string | FieldPath, directionStr)
     return this
   }
 
@@ -22,15 +22,15 @@ export class WebQuery<T extends HasId, S> {
     return this
   }
 
-  startAt (snapshot: firestore.DocumentSnapshot): WebQuery<T, S>
+  startAt (snapshot: DocumentSnapshot): WebQuery<T, S>
   startAt (...fieldValues: any[]): WebQuery<T, S>
   startAt (
-    snapshotOrValue: firestore.DocumentSnapshot | unknown,
+    snapshotOrValue: DocumentSnapshot | unknown,
     ...fieldValues: unknown[]
   ): this {
     if (!this.query) throw new Error('no query statement before startAt()')
 
-    if (snapshotOrValue instanceof firestore.DocumentSnapshot) {
+    if (snapshotOrValue instanceof DocumentSnapshot) {
       this.query = this.query.startAt(snapshotOrValue)
     } else {
       this.query = this.query.startAt(snapshotOrValue, ...fieldValues)
@@ -38,15 +38,15 @@ export class WebQuery<T extends HasId, S> {
     return this
   }
 
-  startAfter (snapshot: firestore.DocumentSnapshot): WebQuery<T, S>
+  startAfter (snapshot: DocumentSnapshot): WebQuery<T, S>
   startAfter (...fieldValues: any[]): WebQuery<T, S>
   startAfter (
-    snapshotOrValue: firestore.DocumentSnapshot | unknown,
+    snapshotOrValue: DocumentSnapshot | unknown,
     ...fieldValues: unknown[]
   ): this {
     if (!this.query) throw new Error('no query statement before startAfter()')
 
-    if (snapshotOrValue instanceof firestore.DocumentSnapshot) {
+    if (snapshotOrValue instanceof DocumentSnapshot) {
       this.query = this.query.startAfter(snapshotOrValue)
     } else {
       this.query = this.query.startAfter(snapshotOrValue, ...fieldValues)
@@ -54,10 +54,10 @@ export class WebQuery<T extends HasId, S> {
     return this
   }
 
-  endAt (snapshot: firestore.DocumentSnapshot): WebQuery<T, S>
+  endAt (snapshot: DocumentSnapshot): WebQuery<T, S>
   endAt (...fieldValues: any[]): WebQuery<T, S>
   endAt (
-    snapshotOrValue: firestore.DocumentSnapshot | unknown,
+    snapshotOrValue: DocumentSnapshot | unknown,
     ...fieldValues: unknown[]
   ): this {
     if (!this.query) throw new Error('no query statement before endAt()')
@@ -70,10 +70,10 @@ export class WebQuery<T extends HasId, S> {
     return this
   }
 
-  endBefore (snapshot: firestore.DocumentSnapshot): WebQuery<T, S>
+  endBefore (snapshot: DocumentSnapshot): WebQuery<T, S>
   endBefore (...fieldValues: any[]): WebQuery<T, S>
   endBefore (
-    snapshotOrValue: firestore.DocumentSnapshot | unknown,
+    snapshotOrValue: DocumentSnapshot | unknown,
     ...fieldValues: unknown[]
   ): this {
     if (!this.query) throw new Error('no query statement before endBefore()')
@@ -97,8 +97,8 @@ export class WebQuery<T extends HasId, S> {
   }
 
   onSnapshot (callback: (
-    querySnapshot: firestore.QuerySnapshot,
-    toObject: (documentSnapshot: firestore.DocumentSnapshot) => T
+    querySnapshot: QuerySnapshot,
+    toObject: (documentSnapshot: DocumentSnapshot) => T
     ) => void
   ): () => void {
     if (!this.query) throw new Error('no query statement before onSnapshot()')

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -16,3 +16,16 @@ export type QueryKey<T> = { [K in keyof T]: K }[keyof T] | firestore.FieldPath
 export type OmitId<T> = Omit<T, 'id'>
 export type WebEncodable<T extends HasId, S = firestore.DocumentData> = (obj: OptionalIdStorable<T>) => Storable<S>
 export type WebDecodable<T extends HasId, S = HasIdObject> = (doc: HasSameKeyObject<S> & HasId) => T
+
+// Export Firestore types
+export import Firestore = firestore.Firestore
+export import DocumentReference = firestore.DocumentReference
+export import CollectionReference = firestore.CollectionReference
+export import DocumentSnapshot = firestore.DocumentSnapshot
+export import QuerySnapshot = firestore.QuerySnapshot
+export import Transaction = firestore.Transaction
+export import WriteBatch = firestore.WriteBatch
+export import Query = firestore.Query
+export import WhereFilterOp = firestore.WhereFilterOp
+export import FieldPath = firestore.FieldPath
+export import OrderByDirection = firestore.OrderByDirection

--- a/packages/web/src/web.ts
+++ b/packages/web/src/web.ts
@@ -1,5 +1,4 @@
-import { firestore } from 'firebase/app'
-import { HasId, WebEncodable, WebDecodable, OmitId } from './types'
+import { HasId, WebEncodable, WebDecodable, OmitId, Firestore, Transaction, WriteBatch } from './types'
 import { Context } from './context'
 import { WebCollection } from './collection'
 import { WebQuery } from './query'
@@ -7,7 +6,7 @@ import { WebConverter } from './converter'
 
 export class FirestoreSimpleWeb {
   context: Context
-  constructor (firestore: firestore.Firestore) {
+  constructor (firestore: Firestore) {
     this.context = new Context(firestore)
   }
 
@@ -44,11 +43,11 @@ export class FirestoreSimpleWeb {
     return new WebQuery<T, S>(converter, this.context, query)
   }
 
-  async runTransaction (updateFunction: (tx: firestore.Transaction) => Promise<void>): Promise<void> {
+  async runTransaction (updateFunction: (tx: Transaction) => Promise<void>): Promise<void> {
     return this.context.runTransaction(updateFunction)
   }
 
-  async runBatch (updateFunction: (batch: firestore.WriteBatch) => Promise<void>): Promise<void> {
+  async runBatch (updateFunction: (batch: WriteBatch) => Promise<void>): Promise<void> {
     return this.context.runBatch(updateFunction)
   }
 }


### PR DESCRIPTION
For resolve complexity of Firestore types and code sharing between admin and web, export original Firestore types from our types module.