### PR TITLE
Fix export from index.ts

### DIFF
--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -1,3 +1,5 @@
+// Admin SDK
 export { FirestoreSimple } from './firestore_simple'
-export type { Collection } from './collection'
-export type { Encodable, Decodable } from './types'
+export { Collection } from './collection'
+export { Query } from './query'
+export { Encodable, Decodable } from './types'

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,4 +1,5 @@
 // Web SDK
 export { FirestoreSimple } from './firestore_simple'
-export type { Collection } from './collection'
-export type { Encodable, Decodable } from './types'
+export { Collection } from './collection'
+export { Query } from './query'
+export { Encodable, Decodable } from './types'


### PR DESCRIPTION
- Export 'Query' for using type definition of FirestoreSimple.collectionGroup
- Revert type only export. It introduced TypeScript 3.8, if using old TypeScript fail to build.