### PR TITLE
fix(deps): Fix utility-types devDependencies to dependencies

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.0.0-5"
+  "version": "7.0.0-6"
 }

--- a/packages/admin/package-lock.json
+++ b/packages/admin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@firestore-simple/admin",
-	"version": "7.0.0-5",
+	"version": "7.0.0-6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/admin/package-lock.json
+++ b/packages/admin/package-lock.json
@@ -10616,8 +10616,7 @@
 		"utility-types": {
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
-			"integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
-			"dev": true
+			"integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg=="
 		},
 		"utils-merge": {
 			"version": "1.0.1",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -32,7 +32,8 @@
     "emulators:start": "firebase emulators:start --only firestore"
   },
   "dependencies": {
-    "firebase-admin": "8.10.0"
+    "firebase-admin": "8.10.0",
+    "utility-types": "3.10.0"
   },
   "devDependencies": {
     "@firebase/testing": "0.18.1",
@@ -41,7 +42,6 @@
     "jest": "25.2.3",
     "rimraf": "3.0.2",
     "ts-jest": "25.3.0",
-    "typescript": "3.8.3",
-    "utility-types": "3.10.0"
+    "typescript": "3.8.3"
   }
 }

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firestore-simple/admin",
-  "version": "7.0.0-5",
+  "version": "7.0.0-6",
   "description": "A simple wrapper for Firestore Admin SDK",
   "author": "Kenta Kase <kesin1202000@gmail.com>",
   "homepage": "https://github.com/Kesin11/Firestore-simple/tree/master/packages/admin#readme",

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -10100,8 +10100,7 @@
 		"utility-types": {
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
-			"integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
-			"dev": true
+			"integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg=="
 		},
 		"utils-merge": {
 			"version": "1.0.1",

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@firestore-simple/web",
-	"version": "7.0.0-5",
+	"version": "7.0.0-6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firestore-simple/web",
-  "version": "7.0.0-5",
+  "version": "7.0.0-6",
   "description": "A simple wrapper for Firestore Web SDK",
   "author": "Kenta Kase <kesin1202000@gmail.com>",
   "homepage": "https://github.com/Kesin11/Firestore-simple/tree/master/packages/web#readme",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,7 +32,8 @@
     "emulators:start": "firebase emulators:start --only firestore"
   },
   "dependencies": {
-    "firebase": "7.13.1"
+    "firebase": "7.13.1",
+    "utility-types": "3.10.0"
   },
   "devDependencies": {
     "@firebase/testing": "0.18.1",
@@ -41,7 +42,6 @@
     "jest": "25.2.3",
     "rimraf": "3.0.2",
     "ts-jest": "25.3.0",
-    "typescript": "3.8.3",
-    "utility-types": "3.10.0"
+    "typescript": "3.8.3"
   }
 }


### PR DESCRIPTION
Partial revert #149 

After move utility-types devDependencies, this error raised when build typescript.

```
node_modules/@firestore-simple/admin/dist/converter.d.ts:2:26 - error TS2307: Cannot find module 'utility-types'.
```