### PR TITLE
Bugfix batch methods unexpected commit error.

### DIFF
--- a/packages/admin/__tests__/batch.test.ts
+++ b/packages/admin/__tests__/batch.test.ts
@@ -1,18 +1,30 @@
-import { FirestoreSimple } from '../src'
+import { FirestoreSimple, Collection } from '../src'
 import { AdminFirestoreTestUtil } from './util'
 
 const util = new AdminFirestoreTestUtil()
 const firestore = util.adminFirestore
 const collectionPath = util.collectionPath
-const firestoreSimple = new FirestoreSimple(firestore)
 
-interface TestDoc {
+type TestDoc = {
   id: string,
   title: string,
 }
 
+type InvalidTestDoc = {
+  id: string,
+  title: string | undefined, // Firestore does not accept undefined!
+}
+
 describe('batch', () => {
-  const dao = firestoreSimple.collection<TestDoc>({ path: collectionPath })
+  let firestoreSimple: FirestoreSimple
+  let dao: Collection<TestDoc>
+  let invalidDao: Collection<InvalidTestDoc>
+
+  beforeEach(async () => {
+    firestoreSimple = new FirestoreSimple(firestore)
+    dao = firestoreSimple.collection<TestDoc>({ path: collectionPath })
+    invalidDao = firestoreSimple.collection<InvalidTestDoc>({ path: collectionPath })
+  })
 
   afterAll(async () => {
     await util.deleteApps()
@@ -22,46 +34,96 @@ describe('batch', () => {
     await util.deleteCollection()
   })
 
-  it('bulkAdd', async () => {
-    const docs = [
-      { title: 'aaa' },
-      { title: 'bbb' },
-      { title: 'ccc' },
-    ]
-    await dao.bulkAdd(docs)
-    const fetchedDocs = await dao.fetchAll()
+  describe('bulkAdd', () => {
+    it('should be commited when no error', async () => {
+      const docs = [
+        { title: 'aaa' },
+        { title: 'bbb' },
+        { title: 'ccc' },
+      ]
+      await dao.bulkAdd(docs)
+      const fetchedDocs = await dao.fetchAll()
 
-    const actualTitles = fetchedDocs.map((doc) => doc.title).sort()
-    const expectTitles = docs.map((doc) => doc.title).sort()
-    expect(actualTitles).toEqual(expectTitles)
+      const actualTitles = fetchedDocs.map((doc) => doc.title).sort()
+      const expectTitles = docs.map((doc) => doc.title).sort()
+      expect(actualTitles).toEqual(expectTitles)
+    })
+
+    it('should not be commited when throw some error', async () => {
+      const docs = [
+        { title: 'aaa' },
+        { title: undefined }, // invalid value
+        { title: 'ccc' },
+      ]
+
+      await expect(invalidDao.bulkAdd(docs)).rejects.toThrow()
+
+      const actualDocs = await invalidDao.fetchAll()
+      expect(actualDocs).toEqual([])
+    })
   })
 
-  it('bulkSet', async () => {
-    const docs = [
-      { id: 'test1', title: 'aaa' },
-      { id: 'test2', title: 'bbb' },
-      { id: 'test3', title: 'ccc' },
-    ]
-    await dao.bulkSet(docs)
+  describe('bulkSet', () => {
+    it('should be commited when no error', async () => {
+      const docs = [
+        { id: 'test1', title: 'aaa' },
+        { id: 'test2', title: 'bbb' },
+        { id: 'test3', title: 'ccc' },
+      ]
+      await dao.bulkSet(docs)
 
-    const actualDocs = await dao.fetchAll()
-    expect(actualDocs).toEqual(docs)
+      const actualDocs = await dao.fetchAll()
+      expect(actualDocs).toEqual(docs)
+    })
+
+    it('should not be commited when throw some error', async () => {
+      const docs = [
+        { id: 'test1', title: 'aaa' },
+        { id: 'test2', title: undefined }, // invalid!
+        { id: 'test3', title: 'ccc' },
+      ]
+      await expect(invalidDao.bulkSet(docs)).rejects.toThrow()
+
+      const actualDocs = await invalidDao.fetchAll()
+      expect(actualDocs).toEqual([])
+    })
   })
 
-  it('bulkDelete', async () => {
-    const docs = [
-      { id: 'test1', title: 'aaa' },
-      { id: 'test2', title: 'bbb' },
-      { id: 'test3', title: 'ccc' },
-    ]
-    await dao.set(docs[0])
-    await dao.set(docs[1])
-    await dao.set(docs[2])
+  describe('bulkDelete', () => {
+    it('should be commited when no error', async () => {
+      const docs = [
+        { id: 'test1', title: 'aaa' },
+        { id: 'test2', title: 'bbb' },
+        { id: 'test3', title: 'ccc' },
+      ]
+      await dao.set(docs[0])
+      await dao.set(docs[1])
+      await dao.set(docs[2])
 
-    const docIds = docs.map((doc) => doc.id)
-    await dao.bulkDelete(docIds)
+      const docIds = docs.map((doc) => doc.id)
+      await dao.bulkDelete(docIds)
 
-    const actualDocs = await dao.fetchAll()
-    expect(actualDocs).toEqual([])
+      const actualDocs = await dao.fetchAll()
+      expect(actualDocs).toEqual([])
+    })
+
+    it('should not be commited when throw some error', async () => {
+      const docs = [
+        { id: 'test1', title: 'aaa' },
+        { id: 'test2', title: 'bbb' },
+        { id: 'test3', title: 'ccc' },
+      ]
+      await dao.set(docs[0])
+      await dao.set(docs[1])
+      await dao.set(docs[2])
+
+      const invalidValue = () => { console.log('invalid') }
+      await expect(
+        dao.bulkDelete(['test1', invalidValue, 'test3'] as any[]) // invalid key
+      ).rejects.toThrow()
+
+      const actualDocs = await dao.fetchAll()
+      expect(actualDocs).toEqual(docs)
+    })
   })
 })

--- a/packages/admin/__tests__/run_batch.test.ts
+++ b/packages/admin/__tests__/run_batch.test.ts
@@ -61,6 +61,16 @@ describe('runBatch', () => {
         ).rejects.toThrow()
       })
     })
+
+    it('should be undefined when throw some error in runBatch', async () => {
+      try {
+        await firestoreSimple.runBatch(async () => {
+          await dao.add({ title: undefined } as any) // invalid value
+        })
+      } catch { }
+
+      expect(firestoreSimple.context.batch).toBeUndefined()
+    })
   })
 
   describe('write method', () => {

--- a/packages/admin/src/collection.ts
+++ b/packages/admin/src/collection.ts
@@ -120,19 +120,25 @@ export class Collection<T extends HasId, S = OmitId<T>> {
 
   async bulkAdd (objects: Array<OptionalIdStorable<T>>): Promise<FirebaseFirestore.WriteResult[]> {
     return this.context.runBatch(async () => {
-      objects.forEach((obj) => { this.add(obj) })
+      for (const obj of objects) {
+        await this.add(obj)
+      }
     })
   }
 
   async bulkSet (objects: Array<Storable<T>>): Promise<FirebaseFirestore.WriteResult[]> {
     return this.context.runBatch(async () => {
-      objects.forEach((obj) => { this.set(obj) })
+      for (const obj of objects) {
+        await this.set(obj)
+      }
     })
   }
 
   async bulkDelete (docIds: string[]): Promise<FirebaseFirestore.WriteResult[]> {
     return this.context.runBatch(async () => {
-      docIds.forEach((docId) => { this.delete(docId) })
+      for (const docId of docIds) {
+        await this.delete(docId)
+      }
     })
   }
 

--- a/packages/admin/src/context.ts
+++ b/packages/admin/src/context.ts
@@ -31,10 +31,14 @@ export class Context {
 
     this._batch = this.firestore.batch()
 
-    await updateFunction(this._batch)
-    const writeResults = await this._batch.commit()
-
-    this._batch = undefined
-    return writeResults
+    try {
+      await updateFunction(this._batch)
+      const writeResults = await this._batch.commit()
+      this._batch = undefined
+      return writeResults
+    } catch (err) {
+      this._batch = undefined
+      throw (err)
+    }
   }
 }

--- a/packages/web/__tests__/batch.test.ts
+++ b/packages/web/__tests__/batch.test.ts
@@ -1,4 +1,4 @@
-import { FirestoreSimple } from '../src'
+import { FirestoreSimple, Collection } from '../src'
 import { WebFirestoreTestUtil } from './util'
 
 const util = new WebFirestoreTestUtil()
@@ -10,10 +10,21 @@ type TestDoc = {
   title: string,
 }
 
-const firestoreSimple = new FirestoreSimple(webFirestore)
+type InvalidTestDoc = {
+  id: string,
+  title: string | undefined, // Firestore does not accept undefined!
+}
 
 describe('batch', () => {
-  const dao = firestoreSimple.collection<TestDoc>({ path: collectionPath })
+  let firestoreSimple: FirestoreSimple
+  let dao: Collection<TestDoc>
+  let invalidDao: Collection<InvalidTestDoc>
+
+  beforeEach(async () => {
+    firestoreSimple = new FirestoreSimple(webFirestore)
+    dao = firestoreSimple.collection<TestDoc>({ path: collectionPath })
+    invalidDao = firestoreSimple.collection<InvalidTestDoc>({ path: collectionPath })
+  })
 
   afterAll(async () => {
     await util.deleteApps()
@@ -23,46 +34,95 @@ describe('batch', () => {
     await util.clearFirestoreData()
   })
 
-  it('bulkAdd', async () => {
-    const docs = [
-      { title: 'aaa' },
-      { title: 'bbb' },
-      { title: 'ccc' },
-    ]
-    await dao.bulkAdd(docs)
-    const fetchedDocs = await dao.fetchAll()
+  describe('bulkAdd', () => {
+    it('should be commited when no error', async () => {
+      const docs = [
+        { title: 'aaa' },
+        { title: 'bbb' },
+        { title: 'ccc' },
+      ]
+      await dao.bulkAdd(docs)
+      const fetchedDocs = await dao.fetchAll()
 
-    const actualTitles = fetchedDocs.map((doc) => doc.title).sort()
-    const expectTitles = docs.map((doc) => doc.title).sort()
-    expect(actualTitles).toEqual(expectTitles)
+      const actualTitles = fetchedDocs.map((doc) => doc.title).sort()
+      const expectTitles = docs.map((doc) => doc.title).sort()
+      expect(actualTitles).toEqual(expectTitles)
+    })
+
+    it('should not be commited when throw some error', async () => {
+      const docs = [
+        { title: 'aaa' },
+        { title: undefined }, // invalid value
+        { title: 'ccc' },
+      ]
+
+      await expect(invalidDao.bulkAdd(docs)).rejects.toThrow()
+
+      const actualDocs = await invalidDao.fetchAll()
+      expect(actualDocs).toEqual([])
+    })
   })
 
-  it('bulkSet', async () => {
-    const docs = [
-      { id: 'test1', title: 'aaa' },
-      { id: 'test2', title: 'bbb' },
-      { id: 'test3', title: 'ccc' },
-    ]
-    await dao.bulkSet(docs)
+  describe('bulkSet', () => {
+    it('should be commited when no error', async () => {
+      const docs = [
+        { id: 'test1', title: 'aaa' },
+        { id: 'test2', title: 'bbb' },
+        { id: 'test3', title: 'ccc' },
+      ]
+      await dao.bulkSet(docs)
 
-    const actualDocs = await dao.fetchAll()
-    expect(actualDocs).toEqual(docs)
+      const actualDocs = await dao.fetchAll()
+      expect(actualDocs).toEqual(docs)
+    })
+    it('should not be commited when throw some error', async () => {
+      const docs = [
+        { id: 'test1', title: 'aaa' },
+        { id: 'test2', title: undefined }, // invalid!
+        { id: 'test3', title: 'ccc' },
+      ]
+      await expect(invalidDao.bulkSet(docs)).rejects.toThrow()
+
+      const actualDocs = await invalidDao.fetchAll()
+      expect(actualDocs).toEqual([])
+    })
   })
 
-  it('bulkDelete', async () => {
-    const docs = [
-      { id: 'test1', title: 'aaa' },
-      { id: 'test2', title: 'bbb' },
-      { id: 'test3', title: 'ccc' },
-    ]
-    await dao.set(docs[0])
-    await dao.set(docs[1])
-    await dao.set(docs[2])
+  describe('bulkDelete', () => {
+    it('should be commited when no error', async () => {
+      const docs = [
+        { id: 'test1', title: 'aaa' },
+        { id: 'test2', title: 'bbb' },
+        { id: 'test3', title: 'ccc' },
+      ]
+      await dao.set(docs[0])
+      await dao.set(docs[1])
+      await dao.set(docs[2])
 
-    const docIds = docs.map((doc) => doc.id)
-    await dao.bulkDelete(docIds)
+      const docIds = docs.map((doc) => doc.id)
+      await dao.bulkDelete(docIds)
 
-    const actualDocs = await dao.fetchAll()
-    expect(actualDocs).toEqual([])
+      const actualDocs = await dao.fetchAll()
+      expect(actualDocs).toEqual([])
+    })
+
+    it('should not be commited when throw some error', async () => {
+      const docs = [
+        { id: 'test1', title: 'aaa' },
+        { id: 'test2', title: 'bbb' },
+        { id: 'test3', title: 'ccc' },
+      ]
+      await dao.set(docs[0])
+      await dao.set(docs[1])
+      await dao.set(docs[2])
+
+      const invalidValue = () => { console.log('invalid') }
+      await expect(
+        dao.bulkDelete(['test1', invalidValue, 'test3'] as any[]) // invalid key
+      ).rejects.toThrow()
+
+      const actualDocs = await dao.fetchAll()
+      expect(actualDocs).toEqual(docs)
+    })
   })
 })

--- a/packages/web/__tests__/run_batch.test.ts
+++ b/packages/web/__tests__/run_batch.test.ts
@@ -62,6 +62,16 @@ describe('runBatch', () => {
         ).rejects.toThrow()
       })
     })
+
+    it('should be undefined when throw some error in runBatch', async () => {
+      try {
+        await firestoreSimple.runBatch(async () => {
+          await dao.add({ title: undefined } as any) // invalid value
+        })
+      } catch { }
+
+      expect(firestoreSimple.context.batch).toBeUndefined()
+    })
   })
 
   describe('write method', () => {

--- a/packages/web/src/collection.ts
+++ b/packages/web/src/collection.ts
@@ -115,19 +115,25 @@ export class Collection<T extends HasId, S = OmitId<T>> {
 
   async bulkAdd (objects: Array<OptionalIdStorable<T>>): Promise<void> {
     return this.context.runBatch(async () => {
-      objects.forEach((obj) => { this.add(obj) })
+      for (const obj of objects) {
+        await this.add(obj)
+      }
     })
   }
 
   async bulkSet (objects: Array<Storable<T>>): Promise<void> {
     return this.context.runBatch(async () => {
-      objects.forEach((obj) => { this.set(obj) })
+      for (const obj of objects) {
+        await this.set(obj)
+      }
     })
   }
 
   async bulkDelete (docIds: string[]): Promise<void> {
     return this.context.runBatch(async () => {
-      docIds.forEach((docId) => { this.delete(docId) })
+      for (const docId of docIds) {
+        await this.delete(docId)
+      }
     })
   }
 

--- a/packages/web/src/context.ts
+++ b/packages/web/src/context.ts
@@ -31,9 +31,14 @@ export class Context {
 
     this._batch = this.firestore.batch()
 
-    await updateFunction(this._batch)
-    await this._batch.commit()
-
-    this._batch = undefined
+    try {
+      await updateFunction(this._batch)
+      const writeResults = await this._batch.commit()
+      this._batch = undefined
+      return writeResults
+    } catch (err) {
+      this._batch = undefined
+      throw (err)
+    }
   }
 }


### PR DESCRIPTION
When some error throws in batch methods(`bulkAdd`, `bulkSet`, `bulkDelete` and also `runBatch`), we expect `batch.commit()` does not execute but unfortunately it committed and invalid state will save to Firestore.
And I also found a bug `FirestoreSimple.context.batch` will not be undefined when error throws in `runBatch`.

This pull-request fix these serious bugs. But `runTransaction` also has context bug, I will fix next pull-request.