### PR TITLE
Change firebase-admin and firebase dependency type to peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint --cache \"packages/**/{src,__tests__}/**/*.ts\"",
     "lint:fix": "npm run lint -- --fix",
     "coverage": "codecov",
-    "release:prepublish": "npm run build:clean && lerna publish prerelease --dist-tag=beta",
+    "release:prepublish": "npm run build:clean && lerna publish prerelease --dist-tag=beta -c",
     "release:prepare": "shipjs prepare --dry-run && shipjs prepare",
     "release:trigger": "npm run clean && shipjs trigger"
   },

--- a/packages/admin/package-lock.json
+++ b/packages/admin/package-lock.json
@@ -512,7 +512,8 @@
 		"@firebase/app-types": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-			"integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
+			"integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg==",
+			"dev": true
 		},
 		"@firebase/auth": {
 			"version": "0.14.9",
@@ -526,7 +527,8 @@
 		"@firebase/auth-interop-types": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
-			"integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw=="
+			"integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==",
+			"dev": true
 		},
 		"@firebase/auth-types": {
 			"version": "0.10.1",
@@ -538,6 +540,7 @@
 			"version": "0.1.18",
 			"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
 			"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
+			"dev": true,
 			"requires": {
 				"@firebase/util": "0.3.1",
 				"tslib": "^1.11.1"
@@ -547,6 +550,7 @@
 			"version": "0.6.11",
 			"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.11.tgz",
 			"integrity": "sha512-QOHhB7+CdjVhEXG9CyX0roA9ARJcEuwbozz0Bix+ULuZqjQ58KUFHMH1apW6EEiUP22d/mYD7dNXsUGshjL9PA==",
+			"dev": true,
 			"requires": {
 				"@firebase/auth-interop-types": "0.1.5",
 				"@firebase/component": "0.1.18",
@@ -561,6 +565,7 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.2.tgz",
 			"integrity": "sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==",
+			"dev": true,
 			"requires": {
 				"@firebase/app-types": "0.6.1"
 			}
@@ -707,7 +712,8 @@
 		"@firebase/logger": {
 			"version": "0.2.6",
 			"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-			"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
+			"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
+			"dev": true
 		},
 		"@firebase/messaging": {
 			"version": "0.7.0",
@@ -935,6 +941,7 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
 			"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.11.1"
 			}
@@ -949,6 +956,7 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.3.2.tgz",
 			"integrity": "sha512-W7JRLBEJWYtZQQuGQX06U6GBOSLrSrlvZxv6kGNwJtFrusu6AVgZltQ9Pajuz9Dh9aSXy9aTnBcyxn2/O0EGUw==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"@google-cloud/projectify": "^2.0.0",
@@ -966,24 +974,28 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.0.1.tgz",
 					"integrity": "sha512-ZDG38U/Yy6Zr21LaR3BTiiLtpJl6RkPS/JwoRT453G+6Q1DhlV0waNf8Lfu+YVYGIIxgKnLayJRfYlFJfiI8iQ==",
+					"dev": true,
 					"optional": true
 				},
 				"@google-cloud/promisify": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.2.tgz",
 					"integrity": "sha512-EvuabjzzZ9E2+OaYf+7P9OAiiwbTxKYL0oGLnREQd+Su2NTQBpomkdlkBowFvyWsaV0d1sSGxrKpSNcrhPqbxg==",
+					"dev": true,
 					"optional": true
 				},
 				"bignumber.js": {
 					"version": "9.0.0",
 					"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
 					"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+					"dev": true,
 					"optional": true
 				},
 				"duplexify": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
 					"integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"end-of-stream": "^1.4.1",
@@ -996,6 +1008,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.1.0.tgz",
 					"integrity": "sha512-DDTn3KXVJJigtz+g0J3vhcfbDbKtAroSTxauWsdnP57sM5KZ3d2c/3D9RKFJ86s43hfw6WULg6TXYw/AYiBlpA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abort-controller": "^3.0.0",
@@ -1009,6 +1022,7 @@
 					"version": "4.1.4",
 					"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.1.4.tgz",
 					"integrity": "sha512-5J/GIH0yWt/56R3dNaNWPGQ/zXsZOddYECfJaqxFWgrZ9HC2Kvc5vl9upOgUUHKzURjAVf2N+f6tEJiojqXUuA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"gaxios": "^3.0.0",
@@ -1019,6 +1033,7 @@
 					"version": "6.0.6",
 					"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.6.tgz",
 					"integrity": "sha512-fWYdRdg55HSJoRq9k568jJA1lrhg9i2xgfhVIMJbskUmbDpJGHsbv9l41DGhCDXM21F9Kn4kUwdysgxSYBYJUw==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"arrify": "^2.0.0",
@@ -1036,6 +1051,7 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.2.tgz",
 					"integrity": "sha512-tbjzndQvSIHGBLzHnhDs3cL4RBjLbLXc2pYvGH+imGVu5b4RMAttUTdnmW2UH0t11QeBTXZ7wlXPS7hrypO/tg==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"node-forge": "^0.9.0"
@@ -1045,6 +1061,7 @@
 					"version": "5.0.3",
 					"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.3.tgz",
 					"integrity": "sha512-Nyd1wZCMRc2dj/mAD0LlfQLcAO06uKdpKJXvK85SGrF5+5+Bpfil9u/2aw35ltvEHjvl0h5FMKN5knEU+9JrOg==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"gaxios": "^3.0.0",
@@ -1057,6 +1074,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
 					"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"bignumber.js": "^9.0.0"
@@ -1066,6 +1084,7 @@
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"yallist": "^4.0.0"
@@ -1075,6 +1094,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -1083,6 +1103,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-4.2.0.tgz",
 			"integrity": "sha512-YCiKaTYCbXSoEvZ8cTmpgg4ebAvmFUOu3hj/aX+lHiOK7LsoFVi4jgNknogSqIiv04bxAysTBodpgn8XoZ4l5g==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
@@ -1094,6 +1115,7 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.1.3.tgz",
 					"integrity": "sha512-HtOsk2YUofBcm1GkPqGzb6pwHhv+74eC2CUO229USIDKRtg30ycbZmqC+HdNtY3nHqoc9IgcRlntFgopyQoYCA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"semver": "^6.2.0"
@@ -1103,18 +1125,21 @@
 					"version": "13.13.15",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
 					"integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+					"dev": true,
 					"optional": true
 				},
 				"bignumber.js": {
 					"version": "9.0.0",
 					"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
 					"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+					"dev": true,
 					"optional": true
 				},
 				"gaxios": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.1.0.tgz",
 					"integrity": "sha512-DDTn3KXVJJigtz+g0J3vhcfbDbKtAroSTxauWsdnP57sM5KZ3d2c/3D9RKFJ86s43hfw6WULg6TXYw/AYiBlpA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abort-controller": "^3.0.0",
@@ -1128,6 +1153,7 @@
 					"version": "4.1.4",
 					"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.1.4.tgz",
 					"integrity": "sha512-5J/GIH0yWt/56R3dNaNWPGQ/zXsZOddYECfJaqxFWgrZ9HC2Kvc5vl9upOgUUHKzURjAVf2N+f6tEJiojqXUuA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"gaxios": "^3.0.0",
@@ -1138,6 +1164,7 @@
 					"version": "6.0.6",
 					"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.6.tgz",
 					"integrity": "sha512-fWYdRdg55HSJoRq9k568jJA1lrhg9i2xgfhVIMJbskUmbDpJGHsbv9l41DGhCDXM21F9Kn4kUwdysgxSYBYJUw==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"arrify": "^2.0.0",
@@ -1155,6 +1182,7 @@
 					"version": "2.7.0",
 					"resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.7.0.tgz",
 					"integrity": "sha512-0dBATy8mMVlfOBrT85Q+NzBpZ4OJZUMrPI9wJULpiIDq2w1zlN30Duor+fQUcMEjanYEc72G58M4iUVve0jfXw==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"@grpc/grpc-js": "~1.1.1",
@@ -1177,6 +1205,7 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.2.tgz",
 					"integrity": "sha512-tbjzndQvSIHGBLzHnhDs3cL4RBjLbLXc2pYvGH+imGVu5b4RMAttUTdnmW2UH0t11QeBTXZ7wlXPS7hrypO/tg==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"node-forge": "^0.9.0"
@@ -1186,6 +1215,7 @@
 					"version": "5.0.3",
 					"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.3.tgz",
 					"integrity": "sha512-Nyd1wZCMRc2dj/mAD0LlfQLcAO06uKdpKJXvK85SGrF5+5+Bpfil9u/2aw35ltvEHjvl0h5FMKN5knEU+9JrOg==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"gaxios": "^3.0.0",
@@ -1198,6 +1228,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
 					"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"bignumber.js": "^9.0.0"
@@ -1207,6 +1238,7 @@
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"yallist": "^4.0.0"
@@ -1216,6 +1248,7 @@
 					"version": "6.10.1",
 					"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
 					"integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"@protobufjs/aspromise": "^1.1.2",
@@ -1237,6 +1270,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -1321,6 +1355,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.2.0.tgz",
 			"integrity": "sha512-zxHXZajtVA0Qx9IOnDUDb76mtKn5M20LKV/phmnVos7foozG9YZ6yYod90pRC/GgP3eOgxNYdt6KQcapssPsFw==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"@google-cloud/common": "^3.3.0",
@@ -1349,6 +1384,7 @@
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.4.tgz",
 					"integrity": "sha512-fKI+jYQdV1F9jtG6tSRro3ilNSeBWVmTzxc8Z0kiPRXcj8eshh9fiF8TtxfDefyUKgTdWgHpzGBwLbZ/OGikJg==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"arrify": "^2.0.0",
@@ -1359,12 +1395,14 @@
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.2.tgz",
 					"integrity": "sha512-EvuabjzzZ9E2+OaYf+7P9OAiiwbTxKYL0oGLnREQd+Su2NTQBpomkdlkBowFvyWsaV0d1sSGxrKpSNcrhPqbxg==",
+					"dev": true,
 					"optional": true
 				},
 				"gaxios": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.1.0.tgz",
 					"integrity": "sha512-DDTn3KXVJJigtz+g0J3vhcfbDbKtAroSTxauWsdnP57sM5KZ3d2c/3D9RKFJ86s43hfw6WULg6TXYw/AYiBlpA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abort-controller": "^3.0.0",
@@ -1378,6 +1416,7 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
 					"integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -1398,6 +1437,7 @@
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.3.tgz",
 			"integrity": "sha512-8qvUtGg77G2ZT2HqdqYoM/OY97gQd/0crSG34xNmZ4ZOsv3aQT/FQV9QfZPazTGna6MIoyUd+u6AxsoZjJ/VMQ==",
+			"dev": true,
 			"requires": {
 				"lodash.camelcase": "^4.3.0",
 				"protobufjs": "^6.8.6"
@@ -2004,27 +2044,32 @@
 		"@protobufjs/aspromise": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+			"dev": true
 		},
 		"@protobufjs/base64": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true
 		},
 		"@protobufjs/codegen": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"dev": true
 		},
 		"@protobufjs/eventemitter": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+			"dev": true
 		},
 		"@protobufjs/fetch": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
 			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+			"dev": true,
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.1",
 				"@protobufjs/inquire": "^1.1.0"
@@ -2033,27 +2078,32 @@
 		"@protobufjs/float": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+			"integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+			"dev": true
 		},
 		"@protobufjs/inquire": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+			"dev": true
 		},
 		"@protobufjs/path": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+			"dev": true
 		},
 		"@protobufjs/pool": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+			"dev": true
 		},
 		"@protobufjs/utf8": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+			"dev": true
 		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",
@@ -2092,6 +2142,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+			"dev": true,
 			"optional": true
 		},
 		"@types/babel__core": {
@@ -2206,7 +2257,8 @@
 		"@types/long": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+			"dev": true
 		},
 		"@types/node": {
 			"version": "8.10.59",
@@ -2267,6 +2319,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
 			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
 			"requires": {
 				"event-target-shim": "^5.0.0"
 			}
@@ -2307,6 +2360,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
 			"integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+			"dev": true,
 			"requires": {
 				"debug": "4"
 			}
@@ -2518,7 +2572,8 @@
 		"arrify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+			"dev": true
 		},
 		"as-array": {
 			"version": "2.0.0",
@@ -2760,7 +2815,8 @@
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+			"dev": true
 		},
 		"basic-auth": {
 			"version": "2.0.1",
@@ -3046,12 +3102,14 @@
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+			"dev": true
 		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
 		},
 		"buffer-indexof-polyfill": {
 			"version": "1.0.1",
@@ -3517,6 +3575,7 @@
 			"version": "2.0.18",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
 			"integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+			"dev": true,
 			"requires": {
 				"mime-db": ">= 1.43.0 < 2"
 			}
@@ -3575,6 +3634,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
 			"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -3587,6 +3647,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
 			"integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+			"dev": true,
 			"requires": {
 				"dot-prop": "^5.2.0",
 				"graceful-fs": "^4.1.2",
@@ -3709,7 +3770,8 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"crc": {
 			"version": "3.8.0",
@@ -3772,7 +3834,8 @@
 		"crypto-random-string": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
+			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+			"dev": true
 		},
 		"cssom": {
 			"version": "0.4.4",
@@ -3884,12 +3947,14 @@
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.14.0.tgz",
 			"integrity": "sha512-0wY8b90XjQkRxv3XGT8k1ffyDQOf4+T+2hiWp7rwYgoEn8OyYDsHZdnVrPlzxbwjLUY66mVBXr59eKOwpSV7lw==",
+			"dev": true,
 			"optional": true
 		},
 		"debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"dev": true,
 			"requires": {
 				"ms": "^2.1.1"
 			}
@@ -4023,6 +4088,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
 			"integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+			"dev": true,
 			"requires": {
 				"streamsearch": "0.1.2"
 			}
@@ -4060,6 +4126,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
 			"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+			"dev": true,
 			"requires": {
 				"is-obj": "^2.0.0"
 			}
@@ -4118,6 +4185,7 @@
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
 			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
 				"inherits": "^2.0.1",
@@ -4128,12 +4196,14 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
 				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -4147,7 +4217,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
 				}
 			}
 		},
@@ -4165,6 +4236,7 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
 			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -4223,6 +4295,7 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -4231,6 +4304,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
 			"integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+			"dev": true,
 			"optional": true
 		},
 		"error-ex": {
@@ -4362,7 +4436,8 @@
 		"event-target-shim": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true
 		},
 		"exec-sh": {
 			"version": "0.3.4",
@@ -4596,7 +4671,8 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -4704,7 +4780,8 @@
 		"fast-deep-equal": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -4727,7 +4804,8 @@
 		"fast-text-encoding": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.1.tgz",
-			"integrity": "sha512-x4FEgaz3zNRtJfLFqJmHWxkMDDvXVtaznj2V9jiP8ACUJrUgist4bP9FmDL2Vew2Y9mEQI/tG4GqabaitYp9CQ=="
+			"integrity": "sha512-x4FEgaz3zNRtJfLFqJmHWxkMDDvXVtaznj2V9jiP8ACUJrUgist4bP9FmDL2Vew2Y9mEQI/tG4GqabaitYp9CQ==",
+			"dev": true
 		},
 		"fast-url-parser": {
 			"version": "1.1.3",
@@ -4750,6 +4828,7 @@
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
 			"integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+			"dev": true,
 			"requires": {
 				"websocket-driver": ">=0.5.1"
 			}
@@ -4912,6 +4991,7 @@
 			"version": "9.1.0",
 			"resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-9.1.0.tgz",
 			"integrity": "sha512-tGGREJpoRM/mbV/5bs/q9SQRZkVhxMMq1HIJEzSEh3mtz5hC9VtaCkuLt6chuAsqHMBoc1pvnrGTOC5nOme9VQ==",
+			"dev": true,
 			"requires": {
 				"@firebase/database": "^0.6.10",
 				"@firebase/database-types": "^0.5.2",
@@ -4926,7 +5006,8 @@
 				"@types/node": {
 					"version": "10.17.28",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-					"integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+					"integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
+					"dev": true
 				}
 			}
 		},
@@ -5219,6 +5300,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true,
 			"optional": true
 		},
 		"gaxios": {
@@ -5248,6 +5330,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.1.tgz",
 			"integrity": "sha512-RS1osvAicj9+MjCc6jAcVL1Pt3tg7NK2C2gXM5nqD1Gs0klF2kj5nnAFSBy97JrtslMIQzpb7iSuxaG8rFWd2A==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"abort-controller": "^3.0.0",
@@ -5263,12 +5346,14 @@
 					"version": "9.0.0",
 					"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
 					"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+					"dev": true,
 					"optional": true
 				},
 				"gaxios": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.1.0.tgz",
 					"integrity": "sha512-DDTn3KXVJJigtz+g0J3vhcfbDbKtAroSTxauWsdnP57sM5KZ3d2c/3D9RKFJ86s43hfw6WULg6TXYw/AYiBlpA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abort-controller": "^3.0.0",
@@ -5282,6 +5367,7 @@
 					"version": "4.1.4",
 					"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.1.4.tgz",
 					"integrity": "sha512-5J/GIH0yWt/56R3dNaNWPGQ/zXsZOddYECfJaqxFWgrZ9HC2Kvc5vl9upOgUUHKzURjAVf2N+f6tEJiojqXUuA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"gaxios": "^3.0.0",
@@ -5292,6 +5378,7 @@
 					"version": "6.0.6",
 					"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.6.tgz",
 					"integrity": "sha512-fWYdRdg55HSJoRq9k568jJA1lrhg9i2xgfhVIMJbskUmbDpJGHsbv9l41DGhCDXM21F9Kn4kUwdysgxSYBYJUw==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"arrify": "^2.0.0",
@@ -5309,6 +5396,7 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.2.tgz",
 					"integrity": "sha512-tbjzndQvSIHGBLzHnhDs3cL4RBjLbLXc2pYvGH+imGVu5b4RMAttUTdnmW2UH0t11QeBTXZ7wlXPS7hrypO/tg==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"node-forge": "^0.9.0"
@@ -5318,6 +5406,7 @@
 					"version": "5.0.3",
 					"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.3.tgz",
 					"integrity": "sha512-Nyd1wZCMRc2dj/mAD0LlfQLcAO06uKdpKJXvK85SGrF5+5+Bpfil9u/2aw35ltvEHjvl0h5FMKN5knEU+9JrOg==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"gaxios": "^3.0.0",
@@ -5330,6 +5419,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
 					"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"bignumber.js": "^9.0.0"
@@ -5339,6 +5429,7 @@
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"yallist": "^4.0.0"
@@ -5348,6 +5439,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -5552,7 +5644,8 @@
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+			"dev": true
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -5674,6 +5767,7 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.3.tgz",
 			"integrity": "sha512-OEohGLoUOh+bwsIpHpdvhIXFyRGjeLqJbT8Yc5QTZPbRM7LKywagTQxnX/6mghLDOrD9YGz88hy5mLN2eKflYQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"through2": "^2.0.0"
@@ -5683,6 +5777,7 @@
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -5698,12 +5793,14 @@
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true,
 					"optional": true
 				},
 				"through2": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
 					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"readable-stream": "~2.3.6",
@@ -5769,12 +5866,14 @@
 		"http-parser-js": {
 			"version": "0.4.10",
 			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-			"integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
+			"integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+			"dev": true
 		},
 		"http-proxy-agent": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
 			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"@tootallnate/once": "1",
@@ -5797,6 +5896,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
 			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"dev": true,
 			"requires": {
 				"agent-base": "6",
 				"debug": "4"
@@ -5848,7 +5948,8 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -5863,7 +5964,8 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -6166,7 +6268,8 @@
 		"is-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true
 		},
 		"is-path-inside": {
 			"version": "1.0.1",
@@ -6213,17 +6316,20 @@
 		"is-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+			"dev": true
 		},
 		"is-stream-ended": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
-			"integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
+			"integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
+			"dev": true
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-url": {
 			"version": "1.2.4",
@@ -6268,6 +6374,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true,
 			"optional": true
 		},
 		"isexe": {
@@ -8160,6 +8267,7 @@
 			"version": "8.5.1",
 			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
 			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+			"dev": true,
 			"requires": {
 				"jws": "^3.2.2",
 				"lodash.includes": "^4.3.0",
@@ -8177,6 +8285,7 @@
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
 					"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+					"dev": true,
 					"requires": {
 						"buffer-equal-constant-time": "1.0.1",
 						"ecdsa-sig-formatter": "1.0.11",
@@ -8187,6 +8296,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
 					"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+					"dev": true,
 					"requires": {
 						"jwa": "^1.4.1",
 						"safe-buffer": "^5.0.1"
@@ -8195,7 +8305,8 @@
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
 				}
 			}
 		},
@@ -8215,6 +8326,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
 			"integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+			"dev": true,
 			"requires": {
 				"buffer-equal-constant-time": "1.0.1",
 				"ecdsa-sig-formatter": "1.0.11",
@@ -8225,6 +8337,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
 			"integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+			"dev": true,
 			"requires": {
 				"jwa": "^2.0.0",
 				"safe-buffer": "^5.0.1"
@@ -8380,12 +8493,14 @@
 		"lodash.at": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.at/-/lodash.at-4.6.0.tgz",
-			"integrity": "sha1-k83OZk8KGZTqM9181A4jr9EbD/g="
+			"integrity": "sha1-k83OZk8KGZTqM9181A4jr9EbD/g=",
+			"dev": true
 		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+			"dev": true
 		},
 		"lodash.defaults": {
 			"version": "4.2.0",
@@ -8408,12 +8523,14 @@
 		"lodash.has": {
 			"version": "4.5.2",
 			"resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-			"integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+			"integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
+			"dev": true
 		},
 		"lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+			"dev": true
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -8424,17 +8541,20 @@
 		"lodash.isboolean": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+			"dev": true
 		},
 		"lodash.isinteger": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+			"dev": true
 		},
 		"lodash.isnumber": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+			"dev": true
 		},
 		"lodash.isobject": {
 			"version": "2.4.1",
@@ -8448,12 +8568,14 @@
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"dev": true
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+			"dev": true
 		},
 		"lodash.keys": {
 			"version": "2.4.1",
@@ -8475,7 +8597,8 @@
 		"lodash.once": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+			"dev": true
 		},
 		"lodash.snakecase": {
 			"version": "4.1.1",
@@ -8595,7 +8718,8 @@
 		"long": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+			"dev": true
 		},
 		"lowercase-keys": {
 			"version": "1.0.1",
@@ -8625,6 +8749,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
 			"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+			"dev": true,
 			"requires": {
 				"semver": "^6.0.0"
 			}
@@ -8808,17 +8933,20 @@
 		"mime": {
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-			"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+			"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+			"dev": true
 		},
 		"mime-db": {
 			"version": "1.43.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.26",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
 			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+			"dev": true,
 			"requires": {
 				"mime-db": "1.43.0"
 			}
@@ -8826,7 +8954,8 @@
 		"mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
 		},
 		"mimic-response": {
 			"version": "1.0.1",
@@ -8937,7 +9066,8 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
@@ -9020,12 +9150,14 @@
 		"node-fetch": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+			"dev": true
 		},
 		"node-forge": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
-			"integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
+			"integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
+			"dev": true
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -9201,6 +9333,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -9218,6 +9351,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
 			"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "^2.1.0"
 			}
@@ -9385,7 +9519,8 @@
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true
 		},
 		"package-json": {
 			"version": "4.0.1",
@@ -9575,7 +9710,8 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -9603,6 +9739,7 @@
 			"version": "6.8.9",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.9.tgz",
 			"integrity": "sha512-j2JlRdUeL/f4Z6x4aU4gj9I2LECglC+5qR2TrWb193Tla1qfdaNQTZ8I27Pt7K0Ajmvjjpft7O3KWTGciz4gpw==",
+			"dev": true,
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
@@ -9622,7 +9759,8 @@
 				"@types/node": {
 					"version": "10.17.17",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-					"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+					"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==",
+					"dev": true
 				}
 			}
 		},
@@ -9652,6 +9790,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -9661,6 +9800,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
 			"integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"duplexify": "^4.1.1",
@@ -9672,6 +9812,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
 					"integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"end-of-stream": "^1.4.1",
@@ -9774,6 +9915,7 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -10011,6 +10153,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.1.tgz",
 			"integrity": "sha512-BINDzVtLI2BDukjWmjAIRZ0oglnCAkpP2vQjM3jdLhmT62h0xnQgciPwBRDAvHqpkPT2Wo1XuUyLyn6nbGrZQQ==",
+			"dev": true,
 			"requires": {
 				"debug": "^4.1.1",
 				"through2": "^3.0.1"
@@ -10093,7 +10236,8 @@
 		"safe-buffer": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -10263,7 +10407,8 @@
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true
 		},
 		"semver-diff": {
 			"version": "2.1.0",
@@ -10412,7 +10557,8 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"simple-swizzle": {
 			"version": "0.2.2",
@@ -10439,6 +10585,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
 			"integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0=",
+			"dev": true,
 			"optional": true
 		},
 		"snapdragon": {
@@ -10728,6 +10875,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
 			"integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"stubs": "^3.0.0"
@@ -10736,12 +10884,14 @@
 		"stream-shift": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+			"dev": true
 		},
 		"streamsearch": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-			"integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+			"integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+			"dev": true
 		},
 		"string-length": {
 			"version": "4.0.1",
@@ -10768,6 +10918,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			},
@@ -10775,7 +10926,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
 				}
 			}
 		},
@@ -10816,6 +10968,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
 			"integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
+			"dev": true,
 			"optional": true
 		},
 		"superstatic": {
@@ -11189,6 +11342,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.0.tgz",
 			"integrity": "sha512-kWD3sdGmIix6w7c8ZdVKxWq+3YwVPGWz+Mq0wRZXayEKY/YHb63b8uphfBzcFDmyq8frD9+UTc3wLyOhltRbtg==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"http-proxy-agent": "^4.0.0",
@@ -11306,6 +11460,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
 			"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+			"dev": true,
 			"requires": {
 				"readable-stream": "2 || 3"
 			}
@@ -11483,7 +11638,8 @@
 		"tslib": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -11541,12 +11697,14 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true,
 			"optional": true
 		},
 		"typedarray-to-buffer": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
 			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"dev": true,
 			"requires": {
 				"is-typedarray": "^1.0.0"
 			}
@@ -11573,6 +11731,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
 			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+			"dev": true,
 			"requires": {
 				"crypto-random-string": "^2.0.0"
 			}
@@ -11962,7 +12121,8 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"utility-types": {
 			"version": "3.10.0",
@@ -11979,6 +12139,7 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
 			"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+			"dev": true,
 			"optional": true
 		},
 		"v8-to-istanbul": {
@@ -12054,7 +12215,8 @@
 		"walkdir": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
-			"integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ=="
+			"integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
+			"dev": true
 		},
 		"walker": {
 			"version": "1.0.7",
@@ -12084,6 +12246,7 @@
 			"version": "0.7.3",
 			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
 			"integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
+			"dev": true,
 			"requires": {
 				"http-parser-js": ">=0.4.0 <0.4.11",
 				"safe-buffer": ">=5.1.0",
@@ -12093,7 +12256,8 @@
 		"websocket-extensions": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
-			"integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
+			"integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+			"dev": true
 		},
 		"whatwg-encoding": {
 			"version": "1.0.5",
@@ -12276,12 +12440,14 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write-file-atomic": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
 			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4",
 				"is-typedarray": "^1.0.0",
@@ -12298,7 +12464,8 @@
 		"xdg-basedir": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
+			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+			"dev": true
 		},
 		"xml": {
 			"version": "1.0.1",
@@ -12339,7 +12506,8 @@
 		"xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"dev": true
 		},
 		"y18n": {
 			"version": "4.0.0",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -32,15 +32,18 @@
     "emulators:start": "firebase emulators:start --only firestore"
   },
   "dependencies": {
-    "firebase-admin": "9.1.0",
-    "utility-types": "3.10.0"
+    "utility-types": "^3.10.0"
+  },
+  "peerDependencies": {
+    "firebase-admin": "^9.1.0"
   },
   "devDependencies": {
     "@firebase/testing": "0.20.11",
     "@types/jest": "26.0.10",
+    "firebase-admin": "9.1.0",
     "firebase-tools": "8.7.0",
     "jest": "26.4.0",
-    "jest-junit": "^11.1.0",
+    "jest-junit": "11.1.0",
     "rimraf": "3.0.2",
     "ts-jest": "26.2.0",
     "typescript": "3.9.7"

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -418,6 +418,7 @@
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.4.2.tgz",
 			"integrity": "sha512-WCoeUAO3lP6ikHJ3/XYptV90fpTidzTS9VpAfiVQK8gl9w1zvvKSavY9U3+EVG3frOPCFdE5DBO4MYrUw4gaqw==",
+			"dev": true,
 			"requires": {
 				"@firebase/analytics-types": "0.3.1",
 				"@firebase/component": "0.1.18",
@@ -430,12 +431,14 @@
 		"@firebase/analytics-types": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.3.1.tgz",
-			"integrity": "sha512-63vVJ5NIBh/JF8l9LuPrQYSzFimk7zYHySQB4Dk9rVdJ8kV/vGQoVTvRu1UW05sEc2Ug5PqtEChtTHU+9hvPcA=="
+			"integrity": "sha512-63vVJ5NIBh/JF8l9LuPrQYSzFimk7zYHySQB4Dk9rVdJ8kV/vGQoVTvRu1UW05sEc2Ug5PqtEChtTHU+9hvPcA==",
+			"dev": true
 		},
 		"@firebase/app": {
 			"version": "0.6.10",
 			"resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.10.tgz",
 			"integrity": "sha512-USg/AbgqBERhY0LayrKmmp7pka08WPa7OlFI46kaNW1pA2mUNf/ifTaxhCr2hGg/eWI0zPhpbEvtGQhSJ/QqWg==",
+			"dev": true,
 			"requires": {
 				"@firebase/app-types": "0.6.1",
 				"@firebase/component": "0.1.18",
@@ -449,12 +452,14 @@
 		"@firebase/app-types": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-			"integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
+			"integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg==",
+			"dev": true
 		},
 		"@firebase/auth": {
 			"version": "0.14.9",
 			"resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.14.9.tgz",
 			"integrity": "sha512-PxYa2r5qUEdheXTvqROFrMstK8W4uPiP7NVfp+2Bec+AjY5PxZapCx/YFDLkU0D7YBI82H74PtZrzdJZw7TJ4w==",
+			"dev": true,
 			"requires": {
 				"@firebase/auth-types": "0.10.1"
 			}
@@ -462,17 +467,20 @@
 		"@firebase/auth-interop-types": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
-			"integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw=="
+			"integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==",
+			"dev": true
 		},
 		"@firebase/auth-types": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.1.tgz",
-			"integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw=="
+			"integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw==",
+			"dev": true
 		},
 		"@firebase/component": {
 			"version": "0.1.18",
 			"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
 			"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
+			"dev": true,
 			"requires": {
 				"@firebase/util": "0.3.1",
 				"tslib": "^1.11.1"
@@ -482,6 +490,7 @@
 			"version": "0.6.11",
 			"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.11.tgz",
 			"integrity": "sha512-QOHhB7+CdjVhEXG9CyX0roA9ARJcEuwbozz0Bix+ULuZqjQ58KUFHMH1apW6EEiUP22d/mYD7dNXsUGshjL9PA==",
+			"dev": true,
 			"requires": {
 				"@firebase/auth-interop-types": "0.1.5",
 				"@firebase/component": "0.1.18",
@@ -496,6 +505,7 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.2.tgz",
 			"integrity": "sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==",
+			"dev": true,
 			"requires": {
 				"@firebase/app-types": "0.6.1"
 			}
@@ -504,6 +514,7 @@
 			"version": "1.16.4",
 			"resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.16.4.tgz",
 			"integrity": "sha512-Ur+I8a8RkkbbJRsebkYAUwKFkbh9FemDxTFD/2Vp01pAPM8S3MoIcVegAfTvnPlG/ObBq5O7wI4CRA6b/G/Iyg==",
+			"dev": true,
 			"requires": {
 				"@firebase/component": "0.1.18",
 				"@firebase/firestore-types": "1.12.0",
@@ -519,19 +530,22 @@
 				"node-fetch": {
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+					"dev": true
 				}
 			}
 		},
 		"@firebase/firestore-types": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.12.0.tgz",
-			"integrity": "sha512-OqNxVb63wPZdUc7YnpacAW1WNIMSKERSewCRi+unCQ0YI0KNfrDSypyGCyel+S3GdOtKMk9KnvDknaGbnaFX4g=="
+			"integrity": "sha512-OqNxVb63wPZdUc7YnpacAW1WNIMSKERSewCRi+unCQ0YI0KNfrDSypyGCyel+S3GdOtKMk9KnvDknaGbnaFX4g==",
+			"dev": true
 		},
 		"@firebase/functions": {
 			"version": "0.4.50",
 			"resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.50.tgz",
 			"integrity": "sha512-eBsNrUm/Jfc/xsQXmxQRSkEg6pwHlMd2hice8N90/EeqgwqS/SCvC+O9cJITLlXroAghb9jWDWRvAkDU/TOhpw==",
+			"dev": true,
 			"requires": {
 				"@firebase/component": "0.1.18",
 				"@firebase/functions-types": "0.3.17",
@@ -543,12 +557,14 @@
 		"@firebase/functions-types": {
 			"version": "0.3.17",
 			"resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.17.tgz",
-			"integrity": "sha512-DGR4i3VI55KnYk4IxrIw7+VG7Q3gA65azHnZxo98Il8IvYLr2UTBlSh72dTLlDf25NW51HqvJgYJDKvSaAeyHQ=="
+			"integrity": "sha512-DGR4i3VI55KnYk4IxrIw7+VG7Q3gA65azHnZxo98Il8IvYLr2UTBlSh72dTLlDf25NW51HqvJgYJDKvSaAeyHQ==",
+			"dev": true
 		},
 		"@firebase/installations": {
 			"version": "0.4.16",
 			"resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.16.tgz",
 			"integrity": "sha512-gqv3IrBUmPWKpH8wLJ0fZcAH1NEXwQhqjqnK3cQXRcIkEARP430cmIAaj7CcPdgdemHX9HqwJG+So/yBHIYXPA==",
+			"dev": true,
 			"requires": {
 				"@firebase/component": "0.1.18",
 				"@firebase/installations-types": "0.3.4",
@@ -560,17 +576,20 @@
 		"@firebase/installations-types": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.3.4.tgz",
-			"integrity": "sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q=="
+			"integrity": "sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q==",
+			"dev": true
 		},
 		"@firebase/logger": {
 			"version": "0.2.6",
 			"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-			"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
+			"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
+			"dev": true
 		},
 		"@firebase/messaging": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.0.tgz",
 			"integrity": "sha512-PTD5pQw9QremOjiWWZYOkzcX6OKByMvlG+NQXdTnyL3kLbE01Bdp9iWhkH6ipNpHYMiwcK1RZD4TLkYVBviBsw==",
+			"dev": true,
 			"requires": {
 				"@firebase/component": "0.1.18",
 				"@firebase/installations": "0.4.16",
@@ -583,12 +602,14 @@
 		"@firebase/messaging-types": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.5.0.tgz",
-			"integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg=="
+			"integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg==",
+			"dev": true
 		},
 		"@firebase/performance": {
 			"version": "0.3.11",
 			"resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.3.11.tgz",
 			"integrity": "sha512-L00vBUa2zzoSSOq3StTN43fPxtJ+myF+t+2kP5bQGHN5WOmf22lIsuEjAy1FAscDjVjhL1k5rKMY332ZwEfblg==",
+			"dev": true,
 			"requires": {
 				"@firebase/component": "0.1.18",
 				"@firebase/installations": "0.4.16",
@@ -601,12 +622,14 @@
 		"@firebase/performance-types": {
 			"version": "0.0.13",
 			"resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.13.tgz",
-			"integrity": "sha512-6fZfIGjQpwo9S5OzMpPyqgYAUZcFzZxHFqOyNtorDIgNXq33nlldTL/vtaUZA8iT9TT5cJlCrF/jthKU7X21EA=="
+			"integrity": "sha512-6fZfIGjQpwo9S5OzMpPyqgYAUZcFzZxHFqOyNtorDIgNXq33nlldTL/vtaUZA8iT9TT5cJlCrF/jthKU7X21EA==",
+			"dev": true
 		},
 		"@firebase/polyfill": {
 			"version": "0.3.36",
 			"resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.36.tgz",
 			"integrity": "sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==",
+			"dev": true,
 			"requires": {
 				"core-js": "3.6.5",
 				"promise-polyfill": "8.1.3",
@@ -616,7 +639,8 @@
 				"whatwg-fetch": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-					"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+					"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+					"dev": true
 				}
 			}
 		},
@@ -624,6 +648,7 @@
 			"version": "0.1.27",
 			"resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.27.tgz",
 			"integrity": "sha512-BGjmQomRKNf+yGJ/3/5Kw6zNLM5jY9oTVjLmYsQXf6U+HMgz6J2H6EVGc1bZW7YSsvak8f6DomxegQtvfvwaMw==",
+			"dev": true,
 			"requires": {
 				"@firebase/component": "0.1.18",
 				"@firebase/installations": "0.4.16",
@@ -636,12 +661,14 @@
 		"@firebase/remote-config-types": {
 			"version": "0.1.9",
 			"resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.1.9.tgz",
-			"integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
+			"integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA==",
+			"dev": true
 		},
 		"@firebase/storage": {
 			"version": "0.3.42",
 			"resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.42.tgz",
 			"integrity": "sha512-FqHDWZPhATQeOFBQUZPsQO7xhnGBxprYVDb9eIjCnh1yRl6WAv/OQGHOF+JU5+H+YkjsKTtr/5VjyDl3Y0UHxw==",
+			"dev": true,
 			"requires": {
 				"@firebase/component": "0.1.18",
 				"@firebase/storage-types": "0.3.13",
@@ -652,7 +679,8 @@
 		"@firebase/storage-types": {
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
-			"integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog=="
+			"integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog==",
+			"dev": true
 		},
 		"@firebase/testing": {
 			"version": "0.20.11",
@@ -908,6 +936,7 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
 			"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.11.1"
 			}
@@ -915,7 +944,8 @@
 		"@firebase/webchannel-wrapper": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.3.0.tgz",
-			"integrity": "sha512-VniCGPIgSGNEgOkh5phb3iKmSGIzcwrccy3IomMFRWPCMiCk2y98UQNJEoDs1yIHtZMstVjYWKYxnunIGzC5UQ=="
+			"integrity": "sha512-VniCGPIgSGNEgOkh5phb3iKmSGIzcwrccy3IomMFRWPCMiCk2y98UQNJEoDs1yIHtZMstVjYWKYxnunIGzC5UQ==",
+			"dev": true
 		},
 		"@google-cloud/paginator": {
 			"version": "2.0.3",
@@ -1009,6 +1039,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.0.5.tgz",
 			"integrity": "sha512-Hm+xOiqAhcpT9RYM8lc15dbQD7aQurM7ZU8ulmulepiPlN7iwBXXwP3vSBUimoFoApRqz7pSIisXU8pZaCB4og==",
+			"dev": true,
 			"requires": {
 				"semver": "^6.2.0"
 			},
@@ -1016,7 +1047,8 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -1024,6 +1056,7 @@
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.3.tgz",
 			"integrity": "sha512-8qvUtGg77G2ZT2HqdqYoM/OY97gQd/0crSG34xNmZ4ZOsv3aQT/FQV9QfZPazTGna6MIoyUd+u6AxsoZjJ/VMQ==",
+			"dev": true,
 			"requires": {
 				"lodash.camelcase": "^4.3.0",
 				"protobufjs": "^6.8.6"
@@ -1599,27 +1632,32 @@
 		"@protobufjs/aspromise": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+			"dev": true
 		},
 		"@protobufjs/base64": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true
 		},
 		"@protobufjs/codegen": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"dev": true
 		},
 		"@protobufjs/eventemitter": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+			"dev": true
 		},
 		"@protobufjs/fetch": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
 			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+			"dev": true,
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.1",
 				"@protobufjs/inquire": "^1.1.0"
@@ -1628,27 +1666,32 @@
 		"@protobufjs/float": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+			"integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+			"dev": true
 		},
 		"@protobufjs/inquire": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+			"dev": true
 		},
 		"@protobufjs/path": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+			"dev": true
 		},
 		"@protobufjs/pool": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+			"dev": true
 		},
 		"@protobufjs/utf8": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+			"dev": true
 		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",
@@ -1795,7 +1838,8 @@
 		"@types/long": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+			"dev": true
 		},
 		"@types/node": {
 			"version": "13.9.1",
@@ -3251,7 +3295,8 @@
 		"core-js": {
 			"version": "3.6.5",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -3571,7 +3616,8 @@
 		"dom-storage": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
-			"integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
+			"integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
+			"dev": true
 		},
 		"domexception": {
 			"version": "2.0.1",
@@ -3685,6 +3731,7 @@
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "~0.4.13"
 			}
@@ -4211,6 +4258,7 @@
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
 			"integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+			"dev": true,
 			"requires": {
 				"websocket-driver": ">=0.5.1"
 			}
@@ -4300,6 +4348,7 @@
 			"version": "7.18.0",
 			"resolved": "https://registry.npmjs.org/firebase/-/firebase-7.18.0.tgz",
 			"integrity": "sha512-RGq0rWX25EDsM21TjRe1FbnygJwHXL7yN4P0Zh2Z7dWrBcfJ8tQpDxgwMDtiJTuo9UYExK3py4wjgpGJBau6wg==",
+			"dev": true,
 			"requires": {
 				"@firebase/analytics": "0.4.2",
 				"@firebase/app": "0.6.10",
@@ -4982,7 +5031,8 @@
 		"http-parser-js": {
 			"version": "0.4.10",
 			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-			"integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
+			"integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+			"dev": true
 		},
 		"http-signature": {
 			"version": "1.2.0",
@@ -5015,6 +5065,7 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -5022,7 +5073,8 @@
 		"idb": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
-			"integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw=="
+			"integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
+			"dev": true
 		},
 		"ieee754": {
 			"version": "1.1.13",
@@ -5400,7 +5452,8 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-stream-ended": {
 			"version": "0.1.4",
@@ -5475,6 +5528,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"dev": true,
 			"requires": {
 				"node-fetch": "^1.0.1",
 				"whatwg-fetch": ">=0.10.0"
@@ -7470,7 +7524,8 @@
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+			"dev": true
 		},
 		"lodash.defaults": {
 			"version": "4.2.0",
@@ -7688,7 +7743,8 @@
 		"long": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+			"dev": true
 		},
 		"lowercase-keys": {
 			"version": "1.0.1",
@@ -8128,6 +8184,7 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"dev": true,
 			"requires": {
 				"encoding": "^0.1.11",
 				"is-stream": "^1.0.1"
@@ -8679,7 +8736,8 @@
 		"promise-polyfill": {
 			"version": "8.1.3",
 			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
-			"integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
+			"integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
+			"dev": true
 		},
 		"prompts": {
 			"version": "2.3.2",
@@ -8695,6 +8753,7 @@
 			"version": "6.8.9",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.9.tgz",
 			"integrity": "sha512-j2JlRdUeL/f4Z6x4aU4gj9I2LECglC+5qR2TrWb193Tla1qfdaNQTZ8I27Pt7K0Ajmvjjpft7O3KWTGciz4gpw==",
+			"dev": true,
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
@@ -8714,7 +8773,8 @@
 				"@types/node": {
 					"version": "10.17.17",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-					"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+					"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==",
+					"dev": true
 				}
 			}
 		},
@@ -9180,7 +9240,8 @@
 		"safe-buffer": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -9194,7 +9255,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -10572,7 +10634,8 @@
 		"tslib": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -11119,6 +11182,7 @@
 			"version": "0.7.3",
 			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
 			"integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
+			"dev": true,
 			"requires": {
 				"http-parser-js": ">=0.4.0 <0.4.11",
 				"safe-buffer": ">=5.1.0",
@@ -11128,7 +11192,8 @@
 		"websocket-extensions": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
-			"integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
+			"integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+			"dev": true
 		},
 		"whatwg-encoding": {
 			"version": "1.0.5",
@@ -11142,7 +11207,8 @@
 		"whatwg-fetch": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+			"dev": true
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
@@ -11375,7 +11441,8 @@
 		"xmlhttprequest": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-			"integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+			"integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,15 +32,18 @@
     "emulators:start": "firebase emulators:start --only firestore"
   },
   "dependencies": {
-    "firebase": "7.18.0",
-    "utility-types": "3.10.0"
+    "utility-types": "^3.10.0"
+  },
+  "peerDependencies": {
+    "firebase": "^7.18.0"
   },
   "devDependencies": {
     "@firebase/testing": "0.20.11",
     "@types/jest": "26.0.10",
+    "firebase": "7.18.0",
     "firebase-tools": "8.7.0",
     "jest": "26.4.0",
-    "jest-junit": "^11.1.0",
+    "jest-junit": "11.1.0",
     "rimraf": "3.0.2",
     "ts-jest": "26.2.0",
     "typescript": "3.9.7"


### PR DESCRIPTION
ref: https://github.com/Kesin11/Firestore-simple/pull/237

Actually, Firestore-simple does not need firebase-admin and firebase as `dependencies`.
This change to allow users can use own firebase version.