### PR TITLE
Replace deprecated @firebase/testing

### DIFF
--- a/packages/admin/package-lock.json
+++ b/packages/admin/package-lock.json
@@ -431,120 +431,16 @@
 				"kuler": "^2.0.0"
 			}
 		},
-		"@firebase/analytics": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.4.2.tgz",
-			"integrity": "sha512-WCoeUAO3lP6ikHJ3/XYptV90fpTidzTS9VpAfiVQK8gl9w1zvvKSavY9U3+EVG3frOPCFdE5DBO4MYrUw4gaqw==",
-			"dev": true,
-			"requires": {
-				"@firebase/analytics-types": "0.3.1",
-				"@firebase/component": "0.1.18",
-				"@firebase/installations": "0.4.16",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.3.1",
-				"tslib": "^1.11.1"
-			},
-			"dependencies": {
-				"@firebase/component": {
-					"version": "0.1.18",
-					"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
-					"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-					"dev": true,
-					"requires": {
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/logger": {
-					"version": "0.2.6",
-					"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-					"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
-					"dev": true
-				},
-				"@firebase/util": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-					"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.11.1"
-					}
-				}
-			}
-		},
-		"@firebase/analytics-types": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.3.1.tgz",
-			"integrity": "sha512-63vVJ5NIBh/JF8l9LuPrQYSzFimk7zYHySQB4Dk9rVdJ8kV/vGQoVTvRu1UW05sEc2Ug5PqtEChtTHU+9hvPcA==",
-			"dev": true
-		},
-		"@firebase/app": {
-			"version": "0.6.10",
-			"resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.10.tgz",
-			"integrity": "sha512-USg/AbgqBERhY0LayrKmmp7pka08WPa7OlFI46kaNW1pA2mUNf/ifTaxhCr2hGg/eWI0zPhpbEvtGQhSJ/QqWg==",
-			"dev": true,
-			"requires": {
-				"@firebase/app-types": "0.6.1",
-				"@firebase/component": "0.1.18",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.3.1",
-				"dom-storage": "2.1.0",
-				"tslib": "^1.11.1",
-				"xmlhttprequest": "1.8.0"
-			},
-			"dependencies": {
-				"@firebase/component": {
-					"version": "0.1.18",
-					"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
-					"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-					"dev": true,
-					"requires": {
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/logger": {
-					"version": "0.2.6",
-					"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-					"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
-					"dev": true
-				},
-				"@firebase/util": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-					"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.11.1"
-					}
-				}
-			}
-		},
 		"@firebase/app-types": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
 			"integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg==",
 			"dev": true
 		},
-		"@firebase/auth": {
-			"version": "0.14.9",
-			"resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.14.9.tgz",
-			"integrity": "sha512-PxYa2r5qUEdheXTvqROFrMstK8W4uPiP7NVfp+2Bec+AjY5PxZapCx/YFDLkU0D7YBI82H74PtZrzdJZw7TJ4w==",
-			"dev": true,
-			"requires": {
-				"@firebase/auth-types": "0.10.1"
-			}
-		},
 		"@firebase/auth-interop-types": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
 			"integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==",
-			"dev": true
-		},
-		"@firebase/auth-types": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.1.tgz",
-			"integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw==",
 			"dev": true
 		},
 		"@firebase/component": {
@@ -581,372 +477,11 @@
 				"@firebase/app-types": "0.6.1"
 			}
 		},
-		"@firebase/firestore": {
-			"version": "1.16.4",
-			"resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.16.4.tgz",
-			"integrity": "sha512-Ur+I8a8RkkbbJRsebkYAUwKFkbh9FemDxTFD/2Vp01pAPM8S3MoIcVegAfTvnPlG/ObBq5O7wI4CRA6b/G/Iyg==",
-			"dev": true,
-			"requires": {
-				"@firebase/component": "0.1.18",
-				"@firebase/firestore-types": "1.12.0",
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.3.1",
-				"@firebase/webchannel-wrapper": "0.3.0",
-				"@grpc/grpc-js": "^1.0.0",
-				"@grpc/proto-loader": "^0.5.0",
-				"node-fetch": "2.6.0",
-				"tslib": "^1.11.1"
-			},
-			"dependencies": {
-				"@firebase/component": {
-					"version": "0.1.18",
-					"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
-					"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-					"dev": true,
-					"requires": {
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/logger": {
-					"version": "0.2.6",
-					"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-					"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
-					"dev": true
-				},
-				"@firebase/util": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-					"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.11.1"
-					}
-				},
-				"@grpc/grpc-js": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.1.3.tgz",
-					"integrity": "sha512-HtOsk2YUofBcm1GkPqGzb6pwHhv+74eC2CUO229USIDKRtg30ycbZmqC+HdNtY3nHqoc9IgcRlntFgopyQoYCA==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.2.0"
-					}
-				}
-			}
-		},
-		"@firebase/firestore-types": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.12.0.tgz",
-			"integrity": "sha512-OqNxVb63wPZdUc7YnpacAW1WNIMSKERSewCRi+unCQ0YI0KNfrDSypyGCyel+S3GdOtKMk9KnvDknaGbnaFX4g==",
-			"dev": true
-		},
-		"@firebase/functions": {
-			"version": "0.4.50",
-			"resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.50.tgz",
-			"integrity": "sha512-eBsNrUm/Jfc/xsQXmxQRSkEg6pwHlMd2hice8N90/EeqgwqS/SCvC+O9cJITLlXroAghb9jWDWRvAkDU/TOhpw==",
-			"dev": true,
-			"requires": {
-				"@firebase/component": "0.1.18",
-				"@firebase/functions-types": "0.3.17",
-				"@firebase/messaging-types": "0.5.0",
-				"isomorphic-fetch": "2.2.1",
-				"tslib": "^1.11.1"
-			},
-			"dependencies": {
-				"@firebase/component": {
-					"version": "0.1.18",
-					"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
-					"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-					"dev": true,
-					"requires": {
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/util": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-					"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.11.1"
-					}
-				}
-			}
-		},
-		"@firebase/functions-types": {
-			"version": "0.3.17",
-			"resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.17.tgz",
-			"integrity": "sha512-DGR4i3VI55KnYk4IxrIw7+VG7Q3gA65azHnZxo98Il8IvYLr2UTBlSh72dTLlDf25NW51HqvJgYJDKvSaAeyHQ==",
-			"dev": true
-		},
-		"@firebase/installations": {
-			"version": "0.4.16",
-			"resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.16.tgz",
-			"integrity": "sha512-gqv3IrBUmPWKpH8wLJ0fZcAH1NEXwQhqjqnK3cQXRcIkEARP430cmIAaj7CcPdgdemHX9HqwJG+So/yBHIYXPA==",
-			"dev": true,
-			"requires": {
-				"@firebase/component": "0.1.18",
-				"@firebase/installations-types": "0.3.4",
-				"@firebase/util": "0.3.1",
-				"idb": "3.0.2",
-				"tslib": "^1.11.1"
-			},
-			"dependencies": {
-				"@firebase/component": {
-					"version": "0.1.18",
-					"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
-					"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-					"dev": true,
-					"requires": {
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/util": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-					"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.11.1"
-					}
-				}
-			}
-		},
-		"@firebase/installations-types": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.3.4.tgz",
-			"integrity": "sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q==",
-			"dev": true
-		},
 		"@firebase/logger": {
 			"version": "0.2.6",
 			"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
 			"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
 			"dev": true
-		},
-		"@firebase/messaging": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.0.tgz",
-			"integrity": "sha512-PTD5pQw9QremOjiWWZYOkzcX6OKByMvlG+NQXdTnyL3kLbE01Bdp9iWhkH6ipNpHYMiwcK1RZD4TLkYVBviBsw==",
-			"dev": true,
-			"requires": {
-				"@firebase/component": "0.1.18",
-				"@firebase/installations": "0.4.16",
-				"@firebase/messaging-types": "0.5.0",
-				"@firebase/util": "0.3.1",
-				"idb": "3.0.2",
-				"tslib": "^1.11.1"
-			},
-			"dependencies": {
-				"@firebase/component": {
-					"version": "0.1.18",
-					"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
-					"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-					"dev": true,
-					"requires": {
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/util": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-					"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.11.1"
-					}
-				}
-			}
-		},
-		"@firebase/messaging-types": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.5.0.tgz",
-			"integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg==",
-			"dev": true
-		},
-		"@firebase/performance": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.3.11.tgz",
-			"integrity": "sha512-L00vBUa2zzoSSOq3StTN43fPxtJ+myF+t+2kP5bQGHN5WOmf22lIsuEjAy1FAscDjVjhL1k5rKMY332ZwEfblg==",
-			"dev": true,
-			"requires": {
-				"@firebase/component": "0.1.18",
-				"@firebase/installations": "0.4.16",
-				"@firebase/logger": "0.2.6",
-				"@firebase/performance-types": "0.0.13",
-				"@firebase/util": "0.3.1",
-				"tslib": "^1.11.1"
-			},
-			"dependencies": {
-				"@firebase/component": {
-					"version": "0.1.18",
-					"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
-					"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-					"dev": true,
-					"requires": {
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/logger": {
-					"version": "0.2.6",
-					"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-					"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
-					"dev": true
-				},
-				"@firebase/util": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-					"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.11.1"
-					}
-				}
-			}
-		},
-		"@firebase/performance-types": {
-			"version": "0.0.13",
-			"resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.13.tgz",
-			"integrity": "sha512-6fZfIGjQpwo9S5OzMpPyqgYAUZcFzZxHFqOyNtorDIgNXq33nlldTL/vtaUZA8iT9TT5cJlCrF/jthKU7X21EA==",
-			"dev": true
-		},
-		"@firebase/polyfill": {
-			"version": "0.3.36",
-			"resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.36.tgz",
-			"integrity": "sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==",
-			"dev": true,
-			"requires": {
-				"core-js": "3.6.5",
-				"promise-polyfill": "8.1.3",
-				"whatwg-fetch": "2.0.4"
-			},
-			"dependencies": {
-				"whatwg-fetch": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-					"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-					"dev": true
-				}
-			}
-		},
-		"@firebase/remote-config": {
-			"version": "0.1.27",
-			"resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.27.tgz",
-			"integrity": "sha512-BGjmQomRKNf+yGJ/3/5Kw6zNLM5jY9oTVjLmYsQXf6U+HMgz6J2H6EVGc1bZW7YSsvak8f6DomxegQtvfvwaMw==",
-			"dev": true,
-			"requires": {
-				"@firebase/component": "0.1.18",
-				"@firebase/installations": "0.4.16",
-				"@firebase/logger": "0.2.6",
-				"@firebase/remote-config-types": "0.1.9",
-				"@firebase/util": "0.3.1",
-				"tslib": "^1.11.1"
-			},
-			"dependencies": {
-				"@firebase/component": {
-					"version": "0.1.18",
-					"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
-					"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-					"dev": true,
-					"requires": {
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/logger": {
-					"version": "0.2.6",
-					"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-					"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
-					"dev": true
-				},
-				"@firebase/util": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-					"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.11.1"
-					}
-				}
-			}
-		},
-		"@firebase/remote-config-types": {
-			"version": "0.1.9",
-			"resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.1.9.tgz",
-			"integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA==",
-			"dev": true
-		},
-		"@firebase/storage": {
-			"version": "0.3.42",
-			"resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.42.tgz",
-			"integrity": "sha512-FqHDWZPhATQeOFBQUZPsQO7xhnGBxprYVDb9eIjCnh1yRl6WAv/OQGHOF+JU5+H+YkjsKTtr/5VjyDl3Y0UHxw==",
-			"dev": true,
-			"requires": {
-				"@firebase/component": "0.1.18",
-				"@firebase/storage-types": "0.3.13",
-				"@firebase/util": "0.3.1",
-				"tslib": "^1.11.1"
-			},
-			"dependencies": {
-				"@firebase/component": {
-					"version": "0.1.18",
-					"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
-					"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-					"dev": true,
-					"requires": {
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/util": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-					"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.11.1"
-					}
-				}
-			}
-		},
-		"@firebase/storage-types": {
-			"version": "0.3.13",
-			"resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
-			"integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog==",
-			"dev": true
-		},
-		"@firebase/testing": {
-			"version": "0.20.11",
-			"resolved": "https://registry.npmjs.org/@firebase/testing/-/testing-0.20.11.tgz",
-			"integrity": "sha512-cXu3B4NDG1HbmZby/lxaY7zAWdrhX/HzTzTkk15d3IJ0v+JlBHBWE8y8969UquoGv6fVcbTstUqMX3jgCRcfuw==",
-			"dev": true,
-			"requires": {
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.3.1",
-				"firebase": "7.18.0",
-				"request": "2.88.2"
-			},
-			"dependencies": {
-				"@firebase/logger": {
-					"version": "0.2.6",
-					"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-					"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
-					"dev": true
-				},
-				"@firebase/util": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-					"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.11.1"
-					}
-				}
-			}
 		},
 		"@firebase/util": {
 			"version": "0.3.2",
@@ -956,12 +491,6 @@
 			"requires": {
 				"tslib": "^1.11.1"
 			}
-		},
-		"@firebase/webchannel-wrapper": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.3.0.tgz",
-			"integrity": "sha512-VniCGPIgSGNEgOkh5phb3iKmSGIzcwrccy3IomMFRWPCMiCk2y98UQNJEoDs1yIHtZMstVjYWKYxnunIGzC5UQ==",
-			"dev": true
 		},
 		"@google-cloud/common": {
 			"version": "3.4.0",
@@ -3702,12 +3231,6 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
-		"core-js": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-			"dev": true
-		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4038,12 +3561,6 @@
 			"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
 			"dev": true
 		},
-		"dom-storage": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
-			"integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
-			"dev": true
-		},
 		"domexception": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -4203,26 +3720,6 @@
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
 			"dev": true
-		},
-		"encoding": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"dev": true,
-			"requires": {
-				"iconv-lite": "^0.6.2"
-			},
-			"dependencies": {
-				"iconv-lite": {
-					"version": "0.6.2",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-					"integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3.0.0"
-					}
-				}
-			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -4917,79 +4414,6 @@
 			"requires": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
-			}
-		},
-		"firebase": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/firebase/-/firebase-7.18.0.tgz",
-			"integrity": "sha512-RGq0rWX25EDsM21TjRe1FbnygJwHXL7yN4P0Zh2Z7dWrBcfJ8tQpDxgwMDtiJTuo9UYExK3py4wjgpGJBau6wg==",
-			"dev": true,
-			"requires": {
-				"@firebase/analytics": "0.4.2",
-				"@firebase/app": "0.6.10",
-				"@firebase/app-types": "0.6.1",
-				"@firebase/auth": "0.14.9",
-				"@firebase/database": "0.6.11",
-				"@firebase/firestore": "1.16.4",
-				"@firebase/functions": "0.4.50",
-				"@firebase/installations": "0.4.16",
-				"@firebase/messaging": "0.7.0",
-				"@firebase/performance": "0.3.11",
-				"@firebase/polyfill": "0.3.36",
-				"@firebase/remote-config": "0.1.27",
-				"@firebase/storage": "0.3.42",
-				"@firebase/util": "0.3.1"
-			},
-			"dependencies": {
-				"@firebase/component": {
-					"version": "0.1.18",
-					"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
-					"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-					"dev": true,
-					"requires": {
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/database": {
-					"version": "0.6.11",
-					"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.11.tgz",
-					"integrity": "sha512-QOHhB7+CdjVhEXG9CyX0roA9ARJcEuwbozz0Bix+ULuZqjQ58KUFHMH1apW6EEiUP22d/mYD7dNXsUGshjL9PA==",
-					"dev": true,
-					"requires": {
-						"@firebase/auth-interop-types": "0.1.5",
-						"@firebase/component": "0.1.18",
-						"@firebase/database-types": "0.5.2",
-						"@firebase/logger": "0.2.6",
-						"@firebase/util": "0.3.1",
-						"faye-websocket": "0.11.3",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/database-types": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.2.tgz",
-					"integrity": "sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==",
-					"dev": true,
-					"requires": {
-						"@firebase/app-types": "0.6.1"
-					}
-				},
-				"@firebase/logger": {
-					"version": "0.2.6",
-					"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-					"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
-					"dev": true
-				},
-				"@firebase/util": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-					"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.11.1"
-					}
-				}
 			}
 		},
 		"firebase-admin": {
@@ -5935,12 +5359,6 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
-		"idb": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
-			"integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
-			"dev": true
-		},
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -6397,34 +5815,6 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"dev": true,
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
-			},
-			"dependencies": {
-				"is-stream": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-					"dev": true
-				},
-				"node-fetch": {
-					"version": "1.7.3",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-					"dev": true,
-					"requires": {
-						"encoding": "^0.1.11",
-						"is-stream": "^1.0.1"
-					}
-				}
-			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -9700,12 +9090,6 @@
 			"integrity": "sha512-mgsWQuG4kJ1dtO6e/QlNDLFtMkMzzecsC69aI5hlLEjGHFNpHrvGhFi4LiK5jg2SMQj74/diH+wZliL9LpGsyA==",
 			"dev": true
 		},
-		"promise-polyfill": {
-			"version": "8.1.3",
-			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
-			"integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
-			"dev": true
-		},
 		"prompts": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
@@ -11868,12 +11252,6 @@
 				"iconv-lite": "0.4.24"
 			}
 		},
-		"whatwg-fetch": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz",
-			"integrity": "sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==",
-			"dev": true
-		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -12103,12 +11481,6 @@
 			"version": "0.1.31",
 			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
 			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-			"dev": true
-		},
-		"xmlhttprequest": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-			"integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
 			"dev": true
 		},
 		"xtend": {

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -38,7 +38,6 @@
     "firebase-admin": "^9.1.0"
   },
   "devDependencies": {
-    "@firebase/testing": "0.20.11",
     "@types/jest": "26.0.14",
     "firebase-admin": "9.2.0",
     "firebase-tools": "8.11.0",

--- a/packages/web/__tests__/util.ts
+++ b/packages/web/__tests__/util.ts
@@ -1,5 +1,5 @@
 // import fs from 'fs'
-import * as firebase from '@firebase/testing'
+import * as firebase from '@firebase/rules-unit-testing'
 import crypto from 'crypto'
 
 // This is workaround for avoid error which occure using firestore.FieldValue.increment() with update() or set()

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -447,12 +447,6 @@
 				}
 			}
 		},
-		"@firebase/analytics-types": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.3.1.tgz",
-			"integrity": "sha512-63vVJ5NIBh/JF8l9LuPrQYSzFimk7zYHySQB4Dk9rVdJ8kV/vGQoVTvRu1UW05sEc2Ug5PqtEChtTHU+9hvPcA==",
-			"dev": true
-		},
 		"@firebase/app": {
 			"version": "0.6.11",
 			"resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.11.tgz",
@@ -683,6 +677,86 @@
 			"integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA==",
 			"dev": true
 		},
+		"@firebase/rules-unit-testing": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-1.0.4.tgz",
+			"integrity": "sha512-Dhhl+XpfUvOB/q0sXOgCPRLuM1rkvKdu0b+1eBvaAcmiF1B2cSvTc9qqT8Jsyt3/WpMak9c9rEqnyCbnwZtC7w==",
+			"dev": true,
+			"requires": {
+				"@firebase/logger": "0.2.6",
+				"@firebase/util": "0.3.2",
+				"firebase": "7.21.1",
+				"request": "2.88.2"
+			},
+			"dependencies": {
+				"@firebase/database": {
+					"version": "0.6.13",
+					"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.13.tgz",
+					"integrity": "sha512-NommVkAPzU7CKd1gyehmi3lz0K78q0KOfiex7Nfy7MBMwknLm7oNqKovXSgQV1PCLvKXvvAplDSFhDhzIf9obA==",
+					"dev": true,
+					"requires": {
+						"@firebase/auth-interop-types": "0.1.5",
+						"@firebase/component": "0.1.19",
+						"@firebase/database-types": "0.5.2",
+						"@firebase/logger": "0.2.6",
+						"@firebase/util": "0.3.2",
+						"faye-websocket": "0.11.3",
+						"tslib": "^1.11.1"
+					}
+				},
+				"@firebase/firestore": {
+					"version": "1.17.1",
+					"resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.17.1.tgz",
+					"integrity": "sha512-FJlNmFIBr9wrkA5g9JBPJWPmxYIzUhBDfsJGHNTUCxMbwm12pz/1Y6CW56kvZOgl6l+iPNlF911iduUDFzNUqw==",
+					"dev": true,
+					"requires": {
+						"@firebase/component": "0.1.19",
+						"@firebase/firestore-types": "1.13.0",
+						"@firebase/logger": "0.2.6",
+						"@firebase/util": "0.3.2",
+						"@firebase/webchannel-wrapper": "0.3.0",
+						"@grpc/grpc-js": "^1.0.0",
+						"@grpc/proto-loader": "^0.5.0",
+						"node-fetch": "2.6.1",
+						"tslib": "^1.11.1"
+					}
+				},
+				"@firebase/firestore-types": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.13.0.tgz",
+					"integrity": "sha512-QF5CAuYOHE6Zbsn1uEg6wkl836iP+i6C0C/Zs3kF60eebxZvTWp8JSZk19Ar+jj4w+ye8/7H5olu5CqDNjWpEA==",
+					"dev": true
+				},
+				"firebase": {
+					"version": "7.21.1",
+					"resolved": "https://registry.npmjs.org/firebase/-/firebase-7.21.1.tgz",
+					"integrity": "sha512-ogqWUXIP2/1BTee112QJiAjgch/Ig7pzlAw2mfWOhl9E0IUX46OKv0hypLX62MBgaAKwPHfICIwsWOCxlQ9dZQ==",
+					"dev": true,
+					"requires": {
+						"@firebase/analytics": "0.5.0",
+						"@firebase/app": "0.6.11",
+						"@firebase/app-types": "0.6.1",
+						"@firebase/auth": "0.14.9",
+						"@firebase/database": "0.6.13",
+						"@firebase/firestore": "1.17.1",
+						"@firebase/functions": "0.4.51",
+						"@firebase/installations": "0.4.17",
+						"@firebase/messaging": "0.7.1",
+						"@firebase/performance": "0.4.1",
+						"@firebase/polyfill": "0.3.36",
+						"@firebase/remote-config": "0.1.28",
+						"@firebase/storage": "0.3.43",
+						"@firebase/util": "0.3.2"
+					}
+				},
+				"node-fetch": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+					"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+					"dev": true
+				}
+			}
+		},
 		"@firebase/storage": {
 			"version": "0.3.43",
 			"resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.43.tgz",
@@ -700,256 +774,6 @@
 			"resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
 			"integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog==",
 			"dev": true
-		},
-		"@firebase/testing": {
-			"version": "0.20.11",
-			"resolved": "https://registry.npmjs.org/@firebase/testing/-/testing-0.20.11.tgz",
-			"integrity": "sha512-cXu3B4NDG1HbmZby/lxaY7zAWdrhX/HzTzTkk15d3IJ0v+JlBHBWE8y8969UquoGv6fVcbTstUqMX3jgCRcfuw==",
-			"dev": true,
-			"requires": {
-				"@firebase/logger": "0.2.6",
-				"@firebase/util": "0.3.1",
-				"firebase": "7.18.0",
-				"request": "2.88.2"
-			},
-			"dependencies": {
-				"@firebase/analytics": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.4.2.tgz",
-					"integrity": "sha512-WCoeUAO3lP6ikHJ3/XYptV90fpTidzTS9VpAfiVQK8gl9w1zvvKSavY9U3+EVG3frOPCFdE5DBO4MYrUw4gaqw==",
-					"dev": true,
-					"requires": {
-						"@firebase/analytics-types": "0.3.1",
-						"@firebase/component": "0.1.18",
-						"@firebase/installations": "0.4.16",
-						"@firebase/logger": "0.2.6",
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/app": {
-					"version": "0.6.10",
-					"resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.10.tgz",
-					"integrity": "sha512-USg/AbgqBERhY0LayrKmmp7pka08WPa7OlFI46kaNW1pA2mUNf/ifTaxhCr2hGg/eWI0zPhpbEvtGQhSJ/QqWg==",
-					"dev": true,
-					"requires": {
-						"@firebase/app-types": "0.6.1",
-						"@firebase/component": "0.1.18",
-						"@firebase/logger": "0.2.6",
-						"@firebase/util": "0.3.1",
-						"dom-storage": "2.1.0",
-						"tslib": "^1.11.1",
-						"xmlhttprequest": "1.8.0"
-					}
-				},
-				"@firebase/auth": {
-					"version": "0.14.9",
-					"resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.14.9.tgz",
-					"integrity": "sha512-PxYa2r5qUEdheXTvqROFrMstK8W4uPiP7NVfp+2Bec+AjY5PxZapCx/YFDLkU0D7YBI82H74PtZrzdJZw7TJ4w==",
-					"dev": true,
-					"requires": {
-						"@firebase/auth-types": "0.10.1"
-					}
-				},
-				"@firebase/component": {
-					"version": "0.1.18",
-					"resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
-					"integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-					"dev": true,
-					"requires": {
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/database": {
-					"version": "0.6.11",
-					"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.11.tgz",
-					"integrity": "sha512-QOHhB7+CdjVhEXG9CyX0roA9ARJcEuwbozz0Bix+ULuZqjQ58KUFHMH1apW6EEiUP22d/mYD7dNXsUGshjL9PA==",
-					"dev": true,
-					"requires": {
-						"@firebase/auth-interop-types": "0.1.5",
-						"@firebase/component": "0.1.18",
-						"@firebase/database-types": "0.5.2",
-						"@firebase/logger": "0.2.6",
-						"@firebase/util": "0.3.1",
-						"faye-websocket": "0.11.3",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/database-types": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.2.tgz",
-					"integrity": "sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==",
-					"dev": true,
-					"requires": {
-						"@firebase/app-types": "0.6.1"
-					}
-				},
-				"@firebase/firestore": {
-					"version": "1.16.4",
-					"resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.16.4.tgz",
-					"integrity": "sha512-Ur+I8a8RkkbbJRsebkYAUwKFkbh9FemDxTFD/2Vp01pAPM8S3MoIcVegAfTvnPlG/ObBq5O7wI4CRA6b/G/Iyg==",
-					"dev": true,
-					"requires": {
-						"@firebase/component": "0.1.18",
-						"@firebase/firestore-types": "1.12.0",
-						"@firebase/logger": "0.2.6",
-						"@firebase/util": "0.3.1",
-						"@firebase/webchannel-wrapper": "0.3.0",
-						"@grpc/grpc-js": "^1.0.0",
-						"@grpc/proto-loader": "^0.5.0",
-						"node-fetch": "2.6.0",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/firestore-types": {
-					"version": "1.12.0",
-					"resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.12.0.tgz",
-					"integrity": "sha512-OqNxVb63wPZdUc7YnpacAW1WNIMSKERSewCRi+unCQ0YI0KNfrDSypyGCyel+S3GdOtKMk9KnvDknaGbnaFX4g==",
-					"dev": true
-				},
-				"@firebase/functions": {
-					"version": "0.4.50",
-					"resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.50.tgz",
-					"integrity": "sha512-eBsNrUm/Jfc/xsQXmxQRSkEg6pwHlMd2hice8N90/EeqgwqS/SCvC+O9cJITLlXroAghb9jWDWRvAkDU/TOhpw==",
-					"dev": true,
-					"requires": {
-						"@firebase/component": "0.1.18",
-						"@firebase/functions-types": "0.3.17",
-						"@firebase/messaging-types": "0.5.0",
-						"isomorphic-fetch": "2.2.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/installations": {
-					"version": "0.4.16",
-					"resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.16.tgz",
-					"integrity": "sha512-gqv3IrBUmPWKpH8wLJ0fZcAH1NEXwQhqjqnK3cQXRcIkEARP430cmIAaj7CcPdgdemHX9HqwJG+So/yBHIYXPA==",
-					"dev": true,
-					"requires": {
-						"@firebase/component": "0.1.18",
-						"@firebase/installations-types": "0.3.4",
-						"@firebase/util": "0.3.1",
-						"idb": "3.0.2",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/logger": {
-					"version": "0.2.6",
-					"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-					"integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
-					"dev": true
-				},
-				"@firebase/messaging": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.0.tgz",
-					"integrity": "sha512-PTD5pQw9QremOjiWWZYOkzcX6OKByMvlG+NQXdTnyL3kLbE01Bdp9iWhkH6ipNpHYMiwcK1RZD4TLkYVBviBsw==",
-					"dev": true,
-					"requires": {
-						"@firebase/component": "0.1.18",
-						"@firebase/installations": "0.4.16",
-						"@firebase/messaging-types": "0.5.0",
-						"@firebase/util": "0.3.1",
-						"idb": "3.0.2",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/messaging-types": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.5.0.tgz",
-					"integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg==",
-					"dev": true
-				},
-				"@firebase/performance": {
-					"version": "0.3.11",
-					"resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.3.11.tgz",
-					"integrity": "sha512-L00vBUa2zzoSSOq3StTN43fPxtJ+myF+t+2kP5bQGHN5WOmf22lIsuEjAy1FAscDjVjhL1k5rKMY332ZwEfblg==",
-					"dev": true,
-					"requires": {
-						"@firebase/component": "0.1.18",
-						"@firebase/installations": "0.4.16",
-						"@firebase/logger": "0.2.6",
-						"@firebase/performance-types": "0.0.13",
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/remote-config": {
-					"version": "0.1.27",
-					"resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.27.tgz",
-					"integrity": "sha512-BGjmQomRKNf+yGJ/3/5Kw6zNLM5jY9oTVjLmYsQXf6U+HMgz6J2H6EVGc1bZW7YSsvak8f6DomxegQtvfvwaMw==",
-					"dev": true,
-					"requires": {
-						"@firebase/component": "0.1.18",
-						"@firebase/installations": "0.4.16",
-						"@firebase/logger": "0.2.6",
-						"@firebase/remote-config-types": "0.1.9",
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/storage": {
-					"version": "0.3.42",
-					"resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.42.tgz",
-					"integrity": "sha512-FqHDWZPhATQeOFBQUZPsQO7xhnGBxprYVDb9eIjCnh1yRl6WAv/OQGHOF+JU5+H+YkjsKTtr/5VjyDl3Y0UHxw==",
-					"dev": true,
-					"requires": {
-						"@firebase/component": "0.1.18",
-						"@firebase/storage-types": "0.3.13",
-						"@firebase/util": "0.3.1",
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/storage-types": {
-					"version": "0.3.13",
-					"resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
-					"integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog==",
-					"dev": true
-				},
-				"@firebase/util": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-					"integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.11.1"
-					}
-				},
-				"@firebase/webchannel-wrapper": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.3.0.tgz",
-					"integrity": "sha512-VniCGPIgSGNEgOkh5phb3iKmSGIzcwrccy3IomMFRWPCMiCk2y98UQNJEoDs1yIHtZMstVjYWKYxnunIGzC5UQ==",
-					"dev": true
-				},
-				"firebase": {
-					"version": "7.18.0",
-					"resolved": "https://registry.npmjs.org/firebase/-/firebase-7.18.0.tgz",
-					"integrity": "sha512-RGq0rWX25EDsM21TjRe1FbnygJwHXL7yN4P0Zh2Z7dWrBcfJ8tQpDxgwMDtiJTuo9UYExK3py4wjgpGJBau6wg==",
-					"dev": true,
-					"requires": {
-						"@firebase/analytics": "0.4.2",
-						"@firebase/app": "0.6.10",
-						"@firebase/app-types": "0.6.1",
-						"@firebase/auth": "0.14.9",
-						"@firebase/database": "0.6.11",
-						"@firebase/firestore": "1.16.4",
-						"@firebase/functions": "0.4.50",
-						"@firebase/installations": "0.4.16",
-						"@firebase/messaging": "0.7.0",
-						"@firebase/performance": "0.3.11",
-						"@firebase/polyfill": "0.3.36",
-						"@firebase/remote-config": "0.1.27",
-						"@firebase/storage": "0.3.42",
-						"@firebase/util": "0.3.1"
-					}
-				},
-				"node-fetch": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-					"dev": true
-				}
-			}
 		},
 		"@firebase/util": {
 			"version": "0.3.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -38,7 +38,7 @@
     "firebase": "^7.18.0"
   },
   "devDependencies": {
-    "@firebase/testing": "0.20.11",
+    "@firebase/rules-unit-testing": "1.0.4",
     "@types/jest": "26.0.14",
     "firebase": "7.20.0",
     "firebase-tools": "8.11.0",


### PR DESCRIPTION
`@firebase/testing` was deprecated from Firebase SDK v7.19.0 so it should be replaced newer `@firebase/rules-unit-testing`.
https://firebase.google.com/support/release-notes/js#7.19.0

This patch will be resolving https://github.com/Kesin11/Firestore-simple/pull/284