### PR TITLE
fix: Remove instanceof from query paging methods

### DIFF
--- a/packages/admin/src/query.ts
+++ b/packages/admin/src/query.ts
@@ -28,11 +28,7 @@ export class Query<T extends HasId, S> {
   ): this {
     if (!this.query) throw new Error('no query statement before startAt()')
 
-    if (snapshotOrValue instanceof DocumentSnapshot) {
-      this.query = this.query.startAt(snapshotOrValue)
-    } else {
-      this.query = this.query.startAt(snapshotOrValue, ...fieldValues)
-    }
+    this.query = this.query.startAt(snapshotOrValue, ...fieldValues)
     return this
   }
 
@@ -44,11 +40,7 @@ export class Query<T extends HasId, S> {
   ): this {
     if (!this.query) throw new Error('no query statement before startAfter()')
 
-    if (snapshotOrValue instanceof DocumentSnapshot) {
-      this.query = this.query.startAfter(snapshotOrValue)
-    } else {
-      this.query = this.query.startAfter(snapshotOrValue, ...fieldValues)
-    }
+    this.query = this.query.startAfter(snapshotOrValue, ...fieldValues)
     return this
   }
 
@@ -60,11 +52,7 @@ export class Query<T extends HasId, S> {
   ): this {
     if (!this.query) throw new Error('no query statement before endAt()')
 
-    if (snapshotOrValue instanceof DocumentSnapshot) {
-      this.query = this.query.endAt(snapshotOrValue)
-    } else {
-      this.query = this.query.endAt(snapshotOrValue, ...fieldValues)
-    }
+    this.query = this.query.endAt(snapshotOrValue, ...fieldValues)
     return this
   }
 
@@ -76,11 +64,7 @@ export class Query<T extends HasId, S> {
   ): this {
     if (!this.query) throw new Error('no query statement before endBefore()')
 
-    if (snapshotOrValue instanceof DocumentSnapshot) {
-      this.query = this.query.endBefore(snapshotOrValue)
-    } else {
-      this.query = this.query.endBefore(snapshotOrValue, ...fieldValues)
-    }
+    this.query = this.query.endBefore(snapshotOrValue, ...fieldValues)
     return this
   }
 

--- a/packages/web/src/query.ts
+++ b/packages/web/src/query.ts
@@ -1,5 +1,3 @@
-import { firestore } from 'firebase/app'
-import '@firebase/firestore' // for instanceof firestore.DocumentSnapshot
 import { HasId, QueryKey, DocumentSnapshot, QuerySnapshot, WhereFilterOp, FieldPath, OrderByDirection, Query as FirestoreQuery } from './types'
 import { Converter } from './converter'
 import { Context } from './context'
@@ -30,11 +28,7 @@ export class Query<T extends HasId, S> {
   ): this {
     if (!this.query) throw new Error('no query statement before startAt()')
 
-    if (snapshotOrValue instanceof DocumentSnapshot) {
-      this.query = this.query.startAt(snapshotOrValue)
-    } else {
-      this.query = this.query.startAt(snapshotOrValue, ...fieldValues)
-    }
+    this.query = this.query.startAt(snapshotOrValue, ...fieldValues)
     return this
   }
 
@@ -46,11 +40,7 @@ export class Query<T extends HasId, S> {
   ): this {
     if (!this.query) throw new Error('no query statement before startAfter()')
 
-    if (snapshotOrValue instanceof DocumentSnapshot) {
-      this.query = this.query.startAfter(snapshotOrValue)
-    } else {
-      this.query = this.query.startAfter(snapshotOrValue, ...fieldValues)
-    }
+    this.query = this.query.startAfter(snapshotOrValue, ...fieldValues)
     return this
   }
 
@@ -62,11 +52,7 @@ export class Query<T extends HasId, S> {
   ): this {
     if (!this.query) throw new Error('no query statement before endAt()')
 
-    if (snapshotOrValue instanceof firestore.DocumentSnapshot) {
-      this.query = this.query.endAt(snapshotOrValue)
-    } else {
-      this.query = this.query.endAt(snapshotOrValue, ...fieldValues)
-    }
+    this.query = this.query.endAt(snapshotOrValue, ...fieldValues)
     return this
   }
 
@@ -78,11 +64,7 @@ export class Query<T extends HasId, S> {
   ): this {
     if (!this.query) throw new Error('no query statement before endBefore()')
 
-    if (snapshotOrValue instanceof firestore.DocumentSnapshot) {
-      this.query = this.query.endBefore(snapshotOrValue)
-    } else {
-      this.query = this.query.endBefore(snapshotOrValue, ...fieldValues)
-    }
+    this.query = this.query.endBefore(snapshotOrValue, ...fieldValues)
     return this
   }
 


### PR DESCRIPTION
When updateing firebase, type error like `Cannot find module '@firebase/firestore' from 'src/query.ts'` were often caused by `instanceof` in `@firestore-simple/web`.

That `instanceof` can remove without any impact, so I remove it.