### PR TITLE
ci: Change nodejs container tag "current" to "lts"

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: "node:current"
+      image: "node:lts"
     steps:
     - uses: actions/checkout@v2
     - run: npm ci
@@ -18,7 +18,7 @@ jobs:
   build_and_check_example:
     runs-on: ubuntu-latest
     container:
-      image: "node:current"
+      image: "node:lts"
     steps:
     - uses: actions/checkout@v2
     - run: npm ci


### PR DESCRIPTION
nodejs image tag `node:current` using node 15.0 now. 
Recently, some CI job using this image failed when lerna setup phase, so change image tag to fix lerna error.