### PR TITLE
Add devcontainer and remove firebase_secret.json from CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.148.1/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version: 14, 12, 10
+ARG VARIANT="14-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends openjdk-11-jre git vim
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN sudo -u node npm install -g <your-package-list -here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+	"name": "Node.js & TypeScript",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 10, 12, 14
+		"args": { "VARIANT": "14" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm ci; npm run bootstrap",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -37,8 +37,6 @@ jobs:
     # Prepare
     steps:
     - uses: actions/checkout@v2
-    - name: Create firebase secret json
-      run: echo "${{ secrets.FIREBASE_SECRET }}" | base64 --decode > packages/admin/firebase_secret.json
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node }}

--- a/packages/admin/__tests__/util.ts
+++ b/packages/admin/__tests__/util.ts
@@ -1,7 +1,6 @@
 import { Firestore } from '../src/types'
 import crypto from 'crypto'
 import admin, { ServiceAccount } from 'firebase-admin'
-import serviceAccount from '../firebase_secret.json'
 
 export const deleteCollection = async (firestore: Firestore, collectionPath: string) => {
   const batch = firestore.batch()
@@ -23,6 +22,8 @@ export class AdminFirestoreTestUtil {
 
   static initFirestore (real: boolean) {
     if (real) {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const serviceAccount = require('../firebase_secret.json')
       admin.initializeApp({
         credential: admin.credential.cert(serviceAccount as ServiceAccount),
       })


### PR DESCRIPTION
Add devcontainer for VSCode and Codespaces,
https://code.visualstudio.com/docs/remote/containers

And previously, `admin` package test needs to put firebase service account JSON in your local, but It is no more need to run the test using Firestore emulator.
Replace `import` to `require` to load JSON when if needed.